### PR TITLE
Use logged-in user when checking permissions

### DIFF
--- a/app/container/container.server.ts
+++ b/app/container/container.server.ts
@@ -4,6 +4,7 @@ import { apiClientBuilder } from '../api/apiClientBuilder.server';
 import { createAuthenticator } from '../auth/auth.server';
 import { createSessionStorage } from '../auth/session.server';
 import { appDataSource } from '../db/data-source.server';
+import { createServersRepository } from '../servers/ServersRepository.server';
 import { ServersService } from '../servers/ServersService.server';
 import { SettingsService } from '../settings/SettingsService.server';
 import { TagsService } from '../tags/TagsService.server';
@@ -13,8 +14,10 @@ const bottle = new Bottle();
 
 bottle.serviceFactory('em', () => appDataSource.manager);
 
+bottle.serviceFactory('ServersRepository', createServersRepository, 'em');
+
 bottle.service(TagsService.name, TagsService, 'em');
-bottle.service(ServersService.name, ServersService, 'em');
+bottle.service(ServersService.name, ServersService, 'ServersRepository');
 bottle.service(SettingsService.name, SettingsService, 'em');
 bottle.service(UsersService.name, UsersService, 'em');
 

--- a/app/entities/Server.ts
+++ b/app/entities/Server.ts
@@ -40,6 +40,10 @@ export const ServerEntity = new EntitySchema<Server>({
       joinTable: {
         name: 'user_has_servers',
         joinColumn: {
+          name: 'server_id',
+          referencedColumnName: 'id',
+        },
+        inverseJoinColumn: {
           name: 'user_id',
           referencedColumnName: 'id',
         },

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -13,8 +13,11 @@ export async function action(
   authenticator: Authenticator = serverContainer[Authenticator.name],
 ) {
   const { searchParams } = new URL(request.url);
+  const redirectTo = searchParams.get('redirect-to');
+  const successRedirect = redirectTo && !redirectTo.toLowerCase().startsWith('http') ? redirectTo : '/';
+
   return authenticator.authenticate(CREDENTIALS_STRATEGY, request, {
-    successRedirect: searchParams.get('redirect-to') ?? '/', // TODO Make sure "redirect-to" is a relative URL
+    successRedirect,
     failureRedirect: request.url,
   });
 }

--- a/app/routes/server.$serverId.tags.colors.ts
+++ b/app/routes/server.$serverId.tags.colors.ts
@@ -1,14 +1,21 @@
 import type { ActionFunctionArgs } from '@remix-run/node';
+import { Authenticator } from 'remix-auth';
+import type { SessionData } from '../auth/session.server';
 import { serverContainer } from '../container/container.server';
 import { TagsService } from '../tags/TagsService.server';
 
 export async function action(
   { params, request }: ActionFunctionArgs,
   tagsService: TagsService = serverContainer[TagsService.name],
+  authenticator: Authenticator<SessionData> = serverContainer[Authenticator.name],
 ) {
+  const sessionData = await authenticator.isAuthenticated(request);
+  if (!sessionData) {
+    return new Response(null, { status: 204 });
+  }
+
+  const { userId } = sessionData;
   const { serverId: serverPublicId } = params;
-  // TODO Get UserID from session
-  const userId = 1;
   const colors = await request.json();
 
   await tagsService.updateTagColors({ colors, userId, serverPublicId });

--- a/app/servers/ServersRepository.server.ts
+++ b/app/servers/ServersRepository.server.ts
@@ -1,0 +1,18 @@
+import type { EntityManager } from 'typeorm';
+import type { Server } from '../entities/Server';
+import { ServerEntity } from '../entities/Server';
+
+export function createServersRepository(em: EntityManager) {
+  return em.getRepository(ServerEntity).extend({
+    findByPublicIdAndUserId(publicId: string, userId: number): Promise<Server | null> {
+      const qb = this.createQueryBuilder('server');
+      qb.innerJoin('server.users', 'user')
+        .where('server.publicId = :publicId', { publicId })
+        .andWhere('user.id = :userId', { userId: `${userId}` });
+
+      return qb.getOne();
+    },
+  });
+}
+
+export type ServersRepository = ReturnType<typeof createServersRepository>;

--- a/app/servers/ServersService.server.ts
+++ b/app/servers/ServersService.server.ts
@@ -1,12 +1,11 @@
-import type { EntityManager } from 'typeorm';
 import type { Server } from '../entities/Server';
-import { ServerEntity } from '../entities/Server';
+import type { ServersRepository } from './ServersRepository.server';
 
 export class ServersService {
-  constructor(private readonly em: EntityManager) {}
+  constructor(private readonly serversRepository: ServersRepository) {}
 
-  public async getByPublicId(publicId: string): Promise<Server> {
-    const server = await this.em.findOneBy(ServerEntity, { publicId });
+  public async getByPublicIdAndUser(publicId: string, userId: number): Promise<Server> {
+    const server = await this.serversRepository.findByPublicIdAndUserId(publicId, userId);
     if (!server) {
       throw new Error(`Server with public ID ${publicId} not found`);
     }

--- a/app/tailwind.scss
+++ b/app/tailwind.scss
@@ -1,3 +1,34 @@
-// @tailwind base; // Can't add this for now, as it overrides many styles from bootstrap
+@tailwind base;
+
+@layer base {
+  a {
+    @apply tw-text-shlink-brand;
+  }
+
+  h1 {
+    font-size: 2.5rem;
+  }
+  h2 {
+    font-size: 2rem;
+  }
+  h3 {
+    font-size: 1.75rem;
+  }
+  h4 {
+    font-size: 1.5rem;
+  }
+  h5 {
+    font-size: 1.25rem;
+  }
+  h6 {
+    font-size: 1rem;
+  }
+
+  h1, h2, h3, h4, h5, h6 {
+    font-weight: 500;
+    line-height: 1.2;
+  }
+}
+
 @tailwind components;
 @tailwind utilities;

--- a/test/routes/login.test.tsx
+++ b/test/routes/login.test.tsx
@@ -20,6 +20,8 @@ describe('login', () => {
     it.each([
       ['http://example.com', '/'],
       [`http://example.com?redirect-to=${encodeURIComponent('/foo/bar')}`, '/foo/bar'],
+      [`http://example.com?redirect-to=${encodeURIComponent('https://example.com')}`, '/'],
+      [`http://example.com?redirect-to=${encodeURIComponent('HTTPS://example.com')}`, '/'],
     ])('authenticates user and redirects to expected location', (url, expectedSuccessRedirect) => {
       const request = fromPartial<Request>({ url });
       action(fromPartial({ request }), authenticator);

--- a/test/routes/server.$serverId.tags.colors.test.ts
+++ b/test/routes/server.$serverId.tags.colors.test.ts
@@ -1,23 +1,38 @@
 import type { ActionFunctionArgs } from '@remix-run/node';
 import { fromPartial } from '@total-typescript/shoehorn';
+import type { Authenticator } from 'remix-auth';
+import type { SessionData } from '../../app/auth/session.server';
 import { action } from '../../app/routes/server.$serverId.tags.colors';
 import type { TagsService } from '../../app/tags/TagsService.server';
 
 describe('server.$serverId.tags.colors', () => {
   const updateTagColors = vi.fn();
-  let tagsService: TagsService;
+  const tagsService = fromPartial<TagsService>({ updateTagColors });
+  const isAuthenticated = vi.fn().mockResolvedValue(null);
+  const authenticator = fromPartial<Authenticator<SessionData>>({ isAuthenticated });
 
-  beforeEach(() => {
-    tagsService = fromPartial<TagsService>({ updateTagColors });
+  const callAction = (args: ActionFunctionArgs) => action(args, tagsService, authenticator);
+
+  it('skips updates if there is no user authenticated', async () => {
+    const request = fromPartial<ActionFunctionArgs['request']>({});
+
+    const resp = await callAction(fromPartial({ params: { serverId: '123' }, request }));
+
+    expect(resp.status).toEqual(204);
+    expect(isAuthenticated).toHaveBeenCalledWith(request);
+    expect(updateTagColors).not.toHaveBeenCalled();
   });
 
   it('updates tags in action and returns response', async () => {
+    isAuthenticated.mockResolvedValue({ userId: 1 });
+
     const colors = { foo: 'red' };
     const request = fromPartial<ActionFunctionArgs['request']>({ json: vi.fn().mockResolvedValue(colors) });
 
-    const resp = await action(fromPartial({ params: { serverId: '123' }, request }), tagsService);
+    const resp = await callAction(fromPartial({ params: { serverId: '123' }, request }));
 
-    expect(updateTagColors).toHaveBeenCalled();
     expect(resp.status).toEqual(204);
+    expect(isAuthenticated).toHaveBeenCalledWith(request);
+    expect(updateTagColors).toHaveBeenCalledWith(expect.objectContaining({ colors, userId: 1 }));
   });
 });

--- a/test/servers/ServersService.server.test.ts
+++ b/test/servers/ServersService.server.test.ts
@@ -1,30 +1,30 @@
 import { fromPartial } from '@total-typescript/shoehorn';
-import type { EntityManager } from 'typeorm';
 import type { Server } from '../../app/entities/Server';
+import type { ServersRepository } from '../../app/servers/ServersRepository.server';
 import { ServersService } from '../../app/servers/ServersService.server';
 
 describe('ServersService', () => {
-  const findOneBy = vi.fn();
-  let em: EntityManager;
+  const findByPublicIdAndUserId = vi.fn();
+  let repo: ServersRepository;
   let service: ServersService;
 
   beforeEach(() => {
-    em = fromPartial<EntityManager>({ findOneBy });
-    service = new ServersService(em);
+    repo = fromPartial<ServersRepository>({ findByPublicIdAndUserId });
+    service = new ServersService(repo);
   });
 
-  describe('getByPublicId', () => {
+  describe('getByPublicIdAndUser', () => {
     it('throws error if server is not found', async () => {
-      await expect(() => service.getByPublicId('123')).rejects.toEqual(
+      await expect(() => service.getByPublicIdAndUser('123', 1)).rejects.toEqual(
         new Error('Server with public ID 123 not found'),
       );
     });
 
     it('returns server when found', async () => {
       const server = fromPartial<Server>({});
-      findOneBy.mockResolvedValue(server);
+      findByPublicIdAndUserId.mockResolvedValue(server);
 
-      const result = await service.getByPublicId('123');
+      const result = await service.getByPublicIdAndUser('123', 1);
 
       expect(result).toEqual(server);
     });


### PR DESCRIPTION
Remove hardcoded user IDs and fetch it from the session, if any.