### PR TITLE
Create settings page

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,7 +13,7 @@
   },
   "overrides": [
     {
-      "files": ["**/app/routes/**", "vite*.config.ts"],
+      "files": ["**/app/routes/**", "**/app/root.tsx", "vite*.config.ts"],
       "rules": {
         "no-restricted-exports": "off"
       }

--- a/app/common/MainHeader.tsx
+++ b/app/common/MainHeader.tsx
@@ -1,6 +1,10 @@
-import { faArrowRightFromBracket as faLogout, faChevronDown as arrowIcon } from '@fortawesome/free-solid-svg-icons';
+import {
+  faArrowRightFromBracket as faLogout,
+  faChevronDown as arrowIcon,
+  faCogs,
+} from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Link } from '@remix-run/react';
+import { Link, useLocation } from '@remix-run/react';
 import { useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
 import React from 'react';
@@ -11,6 +15,7 @@ import { ShlinkLogo } from './ShlinkLogo';
 export const MainHeader: FC = () => {
   const session = useSession();
   const [isOpen, toggleCollapse] = useToggle();
+  const { pathname } = useLocation();
 
   return (
     <Navbar color="primary" dark fixed="top" className="main-header" expand="md">
@@ -26,6 +31,11 @@ export const MainHeader: FC = () => {
 
           <Collapse navbar isOpen={isOpen}>
             <Nav navbar className="tw-ml-auto">
+              <NavItem>
+                <NavLink tag={Link} to="/settings" active={pathname.startsWith('/settings')}>
+                  <FontAwesomeIcon icon={faCogs} className="tw-w-[26px] tw-inline-block" /> Settings
+                </NavLink>
+              </NavItem>
               <NavItem>
                 <NavLink tag={Link} to="/logout">
                   <FontAwesomeIcon icon={faLogout} className="tw-w-[26px] tw-inline-block" /> Logout

--- a/app/db/migrations/1714375230731-migration.ts
+++ b/app/db/migrations/1714375230731-migration.ts
@@ -67,6 +67,11 @@ export class Migration1714375230731 implements MigrationInterface {
       ],
     }));
     await queryRunner.createForeignKey('settings', userIdFK());
+    await queryRunner.createIndex('settings', new TableIndex({
+      name: 'IDX_user_settings',
+      isUnique: true,
+      columnNames: ['user_id'],
+    }));
 
     await queryRunner.createTable(new Table({
       name: 'servers',

--- a/app/entities/Settings.ts
+++ b/app/entities/Settings.ts
@@ -1,4 +1,4 @@
-import type { Settings as ShlinkWebComponentSettings } from '@shlinkio/shlink-web-component';
+import type { Settings as ShlinkWebComponentSettings } from '@shlinkio/shlink-web-component/settings';
 import { EntitySchema } from 'typeorm';
 import type { Base } from './Base';
 import { BaseColumnSchema } from './Base';

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -30,7 +30,6 @@ export async function loader(
   return { session };
 }
 
-/* eslint-disable-next-line no-restricted-exports */
 export default function App() {
   const { session } = useLoaderData<typeof loader>();
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -1,16 +1,19 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { Links, Meta, Outlet, Scripts, useLoaderData } from '@remix-run/react';
+import { getSystemPreferredTheme } from '@shlinkio/shlink-frontend-kit';
 import { Authenticator } from 'remix-auth';
 import type { SessionData } from './auth/session-context';
 import { SessionProvider } from './auth/session-context';
 import { MainHeader } from './common/MainHeader';
 import { serverContainer } from './container/container.server';
 import { appDataSource } from './db/data-source.server';
+import { SettingsService } from './settings/SettingsService.server';
 import './index.scss';
 
 export async function loader(
   { request }: LoaderFunctionArgs,
   authenticator: Authenticator<SessionData> = serverContainer[Authenticator.name],
+  settingsService: SettingsService = serverContainer[SettingsService.name],
 ) {
   // FIXME This should be done during server start-up, not here
   if (!appDataSource.isInitialized) {
@@ -27,14 +30,17 @@ export async function loader(
       request,
       { failureRedirect: `/login?redirect-to=${encodeURIComponent(pathname)}` },
     ));
-  return { session };
+
+  const settings = session && await settingsService.userSettings(session.userId);
+
+  return { session, settings };
 }
 
 export default function App() {
-  const { session } = useLoaderData<typeof loader>();
+  const { session, settings } = useLoaderData<typeof loader>();
 
   return (
-    <html lang="en">
+    <html lang="en" data-theme={settings?.ui?.theme ?? getSystemPreferredTheme()}>
       <head>
         <title>Shlink dashboard</title>
 

--- a/app/routes/server.$serverId.$.tsx
+++ b/app/routes/server.$serverId.$.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from '@remix-run/node';
 import { useLoaderData, useLocation, useParams } from '@remix-run/react';
-import type { Settings } from '@shlinkio/shlink-web-component';
+import type { Settings } from '@shlinkio/shlink-web-component/settings';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Authenticator } from 'remix-auth';

--- a/app/routes/settings.$.tsx
+++ b/app/routes/settings.$.tsx
@@ -1,0 +1,62 @@
+import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
+import { useFetcher, useLoaderData } from '@remix-run/react';
+import type { Settings as AppSettings } from '@shlinkio/shlink-web-component/settings';
+import { type ReactNode, useCallback, useEffect, useState } from 'react';
+import { Authenticator } from 'remix-auth';
+import type { SessionData } from '../auth/session-context';
+import { serverContainer } from '../container/container.server';
+import { SettingsService } from '../settings/SettingsService.server';
+
+export async function loader(
+  { request }: LoaderFunctionArgs,
+  settingsService: SettingsService = serverContainer[SettingsService.name],
+  authenticator: Authenticator<SessionData> = serverContainer[Authenticator.name],
+) {
+  const { userId } = await authenticator.isAuthenticated(request, { failureRedirect: '/login' });
+  return settingsService.userSettings(userId);
+}
+
+export async function action(
+  { request }: ActionFunctionArgs,
+  settingsService: SettingsService = serverContainer[SettingsService.name],
+  authenticator: Authenticator<SessionData> = serverContainer[Authenticator.name],
+) {
+  const [sessionData, newSettings] = await Promise.all([
+    authenticator.isAuthenticated(request),
+    request.json(),
+  ]);
+  if (!sessionData) {
+    return {};
+  }
+
+  await settingsService.saveUserSettings(sessionData.userId, newSettings);
+
+  return {};
+}
+
+export default function Settings() {
+  const [component, setComponent] = useState<ReactNode>(null);
+  const settings = useLoaderData<typeof loader>();
+  const fetcher = useFetcher();
+  // TODO Add some deferring
+  const submitSettings = useCallback((newSettings: AppSettings) => fetcher.submit(newSettings, {
+    method: 'POST',
+    encType: 'application/json',
+  }), [fetcher]);
+
+  useEffect(() => {
+    import('@shlinkio/shlink-web-component/settings').then(({ ShlinkWebSettings }) => setComponent(
+      <ShlinkWebSettings
+        settings={settings}
+        defaultShortUrlsListOrdering={{}}
+        updateSettings={submitSettings}
+      />,
+    ));
+  }, [submitSettings, settings]);
+
+  return (
+    <div className="tw-container lg:tw-p-5 tw-p-3 mx-auto">
+      {component}
+    </div>
+  );
+}

--- a/app/routes/settings.$.tsx
+++ b/app/routes/settings.$.tsx
@@ -1,7 +1,8 @@
 import type { ActionFunctionArgs, LoaderFunctionArgs } from '@remix-run/node';
 import { useFetcher, useLoaderData } from '@remix-run/react';
 import type { Settings as AppSettings } from '@shlinkio/shlink-web-component/settings';
-import { type ReactNode, useCallback, useEffect, useState } from 'react';
+import { ShlinkWebSettings } from '@shlinkio/shlink-web-component/settings';
+import { useCallback } from 'react';
 import { Authenticator } from 'remix-auth';
 import type { SessionData } from '../auth/session-context';
 import { serverContainer } from '../container/container.server';
@@ -9,8 +10,8 @@ import { SettingsService } from '../settings/SettingsService.server';
 
 export async function loader(
   { request }: LoaderFunctionArgs,
-  settingsService: SettingsService = serverContainer[SettingsService.name],
   authenticator: Authenticator<SessionData> = serverContainer[Authenticator.name],
+  settingsService: SettingsService = serverContainer[SettingsService.name],
 ) {
   const { userId } = await authenticator.isAuthenticated(request, { failureRedirect: '/login' });
   return settingsService.userSettings(userId);
@@ -18,8 +19,8 @@ export async function loader(
 
 export async function action(
   { request }: ActionFunctionArgs,
-  settingsService: SettingsService = serverContainer[SettingsService.name],
   authenticator: Authenticator<SessionData> = serverContainer[Authenticator.name],
+  settingsService: SettingsService = serverContainer[SettingsService.name],
 ) {
   const [sessionData, newSettings] = await Promise.all([
     authenticator.isAuthenticated(request),
@@ -30,12 +31,10 @@ export async function action(
   }
 
   await settingsService.saveUserSettings(sessionData.userId, newSettings);
-
   return {};
 }
 
 export default function Settings() {
-  const [component, setComponent] = useState<ReactNode>(null);
   const settings = useLoaderData<typeof loader>();
   const fetcher = useFetcher();
   // TODO Add some deferring
@@ -44,19 +43,13 @@ export default function Settings() {
     encType: 'application/json',
   }), [fetcher]);
 
-  useEffect(() => {
-    import('@shlinkio/shlink-web-component/settings').then(({ ShlinkWebSettings }) => setComponent(
-      <ShlinkWebSettings
-        settings={settings}
-        defaultShortUrlsListOrdering={{}}
-        updateSettings={submitSettings}
-      />,
-    ));
-  }, [submitSettings, settings]);
-
   return (
     <div className="tw-container lg:tw-p-5 tw-p-3 mx-auto">
-      {component}
+      <ShlinkWebSettings
+        settings={settings}
+        updateSettings={submitSettings}
+        defaultShortUrlsListOrdering={{}}
+      />
     </div>
   );
 }

--- a/app/settings/SettingsService.server.ts
+++ b/app/settings/SettingsService.server.ts
@@ -1,4 +1,4 @@
-import type { Settings } from '@shlinkio/shlink-web-component';
+import type { Settings } from '@shlinkio/shlink-web-component/settings';
 import type { EntityManager } from 'typeorm';
 import { SettingsEntity } from '../entities/Settings';
 import { UserEntity } from '../entities/User';
@@ -9,10 +9,19 @@ export class SettingsService {
   async userSettings(userId: number): Promise<Settings> {
     const user = await this.em.findOneBy(UserEntity, { id: userId });
     if (!user) {
-      throw new Error(`No user found for id ${userId}`);
+      return {};
     }
 
     const s = await this.em.findOneBy(SettingsEntity, { user });
     return s?.settings ?? {};
+  }
+
+  async saveUserSettings(userId: number, newSettings: Settings): Promise<void> {
+    const user = await this.em.findOneBy(UserEntity, { id: userId });
+    if (!user) {
+      return;
+    }
+
+    await this.em.upsert(SettingsEntity, { user, settings: newSettings }, ['user']);
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@remix-run/react": "^2.9.2",
         "@shlinkio/shlink-frontend-kit": "^0.5.1",
         "@shlinkio/shlink-js-sdk": "^1.1.0",
-        "@shlinkio/shlink-web-component": "^0.6.2",
+        "@shlinkio/shlink-web-component": "^0.7.0",
         "argon2": "^0.40.1",
         "bootstrap": "5.2.3",
         "bottlejs": "^2.0.1",
@@ -2277,16 +2277,16 @@
       "integrity": "sha512-KHvFCmRxkK0H0nja66aGzFrjh5VQpC9m2KXnk/Lb7HMpmoWvf8CZqBYyiPFy3Evaa+GnIHjFv7LtqFce+FVFVg=="
     },
     "node_modules/@shlinkio/shlink-web-component": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-web-component/-/shlink-web-component-0.6.2.tgz",
-      "integrity": "sha512-2R1O0hYmWs11e+4pqn/g3Wk3cbHkhkyE37V73bQghJrmJHKNdBZ7TdsbsWH5eF6RF4UDe1HfG1EJTr+ogqI+mg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@shlinkio/shlink-web-component/-/shlink-web-component-0.7.0.tgz",
+      "integrity": "sha512-83QV1uwq7AjQ/SIQldPHBnMq563kMZKDLi+PxM1pSLElCymtfnS4WtC2c2V4K5eStGy9y42+ZTWKYGZljM6q6g==",
       "dependencies": {
         "@formkit/drag-and-drop": "^0.0.38",
         "@json2csv/plainjs": "^7.0.6",
         "@shlinkio/data-manipulation": "^1.0.3",
         "bottlejs": "^2.0.1",
         "bowser": "^2.11.0",
-        "clsx": "^2.1.0",
+        "clsx": "^2.1.1",
         "compare-versions": "^6.1.0",
         "date-fns": "^3.6.0",
         "event-source-polyfill": "^1.0.31",
@@ -2295,7 +2295,7 @@
         "react-leaflet": "^4.2.1",
         "react-swipeable": "^7.0.1",
         "react-tag-autocomplete": "^7.2.0",
-        "recharts": "^2.12.5"
+        "recharts": "^2.12.7"
       },
       "peerDependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.4.2",
@@ -4582,9 +4582,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
@@ -11973,9 +11973,9 @@
       }
     },
     "node_modules/recharts": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.5.tgz",
-      "integrity": "sha512-Cy+BkqrFIYTHJCyKHJEPvbHE2kVQEP6PKbOHJ8ztRGTAhvHuUnCwDaKVb13OwRFZ0QNUk1QvGTDdgWSMbuMtKw==",
+      "version": "2.12.7",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.12.7.tgz",
+      "integrity": "sha512-hlLJMhPQfv4/3NBSAyq3gzGg4h2v69RJh6KU7b3pXYNNAELs9kEoXOjbkxdXpALqKBoVmVptGfLpxdaVYqjmXQ==",
       "dependencies": {
         "clsx": "^2.0.0",
         "eventemitter3": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@remix-run/react": "^2.9.2",
     "@shlinkio/shlink-frontend-kit": "^0.5.1",
     "@shlinkio/shlink-js-sdk": "^1.1.0",
-    "@shlinkio/shlink-web-component": "^0.6.2",
+    "@shlinkio/shlink-web-component": "^0.7.0",
     "argon2": "^0.40.1",
     "bootstrap": "5.2.3",
     "bottlejs": "^2.0.1",

--- a/test/common/MainHeader.test.tsx
+++ b/test/common/MainHeader.test.tsx
@@ -29,9 +29,11 @@ describe('<MainHeader />', () => {
     if (session) {
       expect(screen.getByRole('button')).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Logout' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
     } else {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'Logout' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeInTheDocument();
     }
   });
 });

--- a/test/routes/settings.test.tsx
+++ b/test/routes/settings.test.tsx
@@ -1,0 +1,83 @@
+import type { ActionFunctionArgs } from '@remix-run/node';
+import { json } from '@remix-run/node';
+import { createRemixStub } from '@remix-run/testing';
+import type { Settings } from '@shlinkio/shlink-web-component/settings';
+import { render, screen, waitFor } from '@testing-library/react';
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { Authenticator } from 'remix-auth';
+import type { SessionData } from '../../app/auth/session-context';
+import SettingsComp, { action as settingsAction, loader } from '../../app/routes/settings.$';
+import type { SettingsService } from '../../app/settings/SettingsService.server';
+
+describe('settings', () => {
+  const isAuthenticated = vi.fn();
+  const authenticator = fromPartial<Authenticator<SessionData>>({ isAuthenticated });
+  const userSettings = vi.fn();
+  const saveUserSettings = vi.fn();
+  const settingsService = fromPartial<SettingsService>({ userSettings, saveUserSettings });
+
+  describe('loader', () => {
+    it('checks if user is authenticated and returns their settings', async () => {
+      const settings = fromPartial<Settings>({
+        ui: { theme: 'dark' },
+      });
+      userSettings.mockResolvedValue(settings);
+      isAuthenticated.mockResolvedValue({ userId: 1 });
+
+      const result = await loader(fromPartial({ request: {} }), authenticator, settingsService);
+
+      expect(result).toEqual(settings);
+      expect(userSettings).toHaveBeenCalled();
+      expect(isAuthenticated).toHaveBeenCalled();
+    });
+  });
+
+  describe('action', () => {
+    const setUp = () => (args: ActionFunctionArgs) => settingsAction(args, authenticator, settingsService);
+    const request = fromPartial<Request>({ json: vi.fn().mockResolvedValue({}) });
+
+    it('does not save settings when user is not logged in', async () => {
+      const action = setUp();
+
+      isAuthenticated.mockResolvedValue(null);
+
+      await action(fromPartial({ request }));
+
+      expect(isAuthenticated).toHaveBeenCalledWith(request);
+      expect(saveUserSettings).not.toHaveBeenCalled();
+    });
+
+    it('saves settings when user is logged in', async () => {
+      const action = setUp();
+
+      isAuthenticated.mockResolvedValue({ userId: 1 });
+
+      await action(fromPartial({ request }));
+
+      expect(isAuthenticated).toHaveBeenCalledWith(request);
+      expect(saveUserSettings).toHaveBeenCalledWith(1, {});
+    });
+  });
+
+  // Skipping for now, as createRemixStub always results in a 404 page
+  describe.skip('<Settings />', () => {
+    const setUp = () => {
+      const RemixStub = createRemixStub([
+        {
+          path: '/settings',
+          Component: SettingsComp,
+          loader: () => json({}),
+          action: () => json({}),
+        },
+      ]);
+      return render(<RemixStub />);
+    };
+
+    it('renders settings component', async () => {
+      setUp();
+
+      await waitFor(() => expect(screen.getByRole('heading', { name: 'User interface' })).toBeInTheDocument());
+      expect(screen.getByRole('heading', { name: 'Real-time updates' })).toBeInTheDocument();
+    });
+  });
+});

--- a/test/settings/SettingsService.server.test.ts
+++ b/test/settings/SettingsService.server.test.ts
@@ -1,0 +1,87 @@
+import type { Settings as ShlinkSettingsConfig } from '@shlinkio/shlink-web-component/settings';
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { EntityManager } from 'typeorm';
+import type { Settings } from '../../app/entities/Settings';
+import { SettingsEntity } from '../../app/entities/Settings';
+import type { User } from '../../app/entities/User';
+import { UserEntity } from '../../app/entities/User';
+import { SettingsService } from '../../app/settings/SettingsService.server';
+
+describe('SettingsService', () => {
+  const findOneBy = vi.fn();
+  const upsert = vi.fn();
+  const em = fromPartial<EntityManager>({ findOneBy, upsert });
+  let settingsService: SettingsService;
+
+  beforeEach(() => {
+    settingsService = new SettingsService(em);
+  });
+
+  describe('userSettings', () => {
+    it('returns no settings when user is not found', async () => {
+      findOneBy.mockResolvedValue(null);
+
+      const settings = await settingsService.userSettings(1);
+
+      expect(settings).toEqual({});
+      expect(findOneBy).toHaveBeenCalledOnce();
+      expect(findOneBy).toHaveBeenCalledWith(UserEntity, { id: 1 });
+    });
+
+    it('returns no settings when user does not have any', async () => {
+      const user = fromPartial<User>({});
+      findOneBy
+        .mockResolvedValueOnce(user)
+        .mockResolvedValueOnce(null);
+
+      const settings = await settingsService.userSettings(1);
+
+      expect(settings).toEqual({});
+      expect(findOneBy).toHaveBeenCalledTimes(2);
+      expect(findOneBy).toHaveBeenNthCalledWith(1, UserEntity, { id: 1 });
+      expect(findOneBy).toHaveBeenNthCalledWith(2, SettingsEntity, { user });
+    });
+
+    it('returns user settings when found', async () => {
+      const user = fromPartial<User>({});
+      const settings = fromPartial<ShlinkSettingsConfig>({
+        ui: { theme: 'dark' },
+        tags: { defaultOrdering: {} },
+        shortUrlCreation: { tagFilteringMode: 'includes' },
+      });
+      findOneBy
+        .mockResolvedValueOnce(user)
+        .mockResolvedValueOnce(fromPartial<Settings>({ settings }));
+
+      const result = await settingsService.userSettings(1);
+
+      expect(result).toEqual(settings);
+      expect(findOneBy).toHaveBeenCalledTimes(2);
+      expect(findOneBy).toHaveBeenNthCalledWith(1, UserEntity, { id: 1 });
+      expect(findOneBy).toHaveBeenNthCalledWith(2, SettingsEntity, { user });
+    });
+  });
+
+  describe('saveUserSettings', () => {
+    it('saves nothing when user is not found', async () => {
+      findOneBy.mockResolvedValue(null);
+
+      await settingsService.saveUserSettings(1, fromPartial({}));
+
+      expect(findOneBy).toHaveBeenCalledWith(UserEntity, { id: 1 });
+      expect(upsert).not.toHaveBeenCalledOnce();
+    });
+
+    it('upserts settings when user is found', async () => {
+      const user = fromPartial<User>({});
+      const newSettings = fromPartial<ShlinkSettingsConfig>({});
+
+      findOneBy.mockResolvedValue(user);
+
+      await settingsService.saveUserSettings(1, newSettings);
+
+      expect(findOneBy).toHaveBeenCalledWith(UserEntity, { id: 1 });
+      expect(upsert).toHaveBeenCalledWith(SettingsEntity, { user, settings: newSettings }, ['user']);
+    });
+  });
+});


### PR DESCRIPTION
Closes #26 

Add a new `/settings` route where users can edit their application settings as long as they are logged in.

The route renders a `ShlinkWebSettings` instance from `@shlinkio/shlink-web-component/settings`.

This PR also adds the logic to apply selected theme to the markup.