### PR TITLE
Extend session on every request, as long as it is not expired already

### DIFF
--- a/app/auth/auth-helper.server.ts
+++ b/app/auth/auth-helper.server.ts
@@ -1,8 +1,8 @@
-import type { SessionStorage } from 'react-router';
+import type { Session, SessionStorage } from 'react-router';
 import { redirect } from 'react-router';
 import type { Authenticator } from 'remix-auth';
 import { CREDENTIALS_STRATEGY } from './auth.server';
-import type { SessionData } from './session-context';
+import type { SessionData, ShlinkSessionData } from './session-context';
 
 /**
  * Wraps a SessionStorage and Authenticator to perform common authentication and session checking/commiting/destroying
@@ -11,13 +11,13 @@ import type { SessionData } from './session-context';
 export class AuthHelper {
   constructor(
     private readonly authenticator: Authenticator<SessionData>,
-    private readonly sessionStorage: SessionStorage<{ sessionData: SessionData }>,
+    private readonly sessionStorage: SessionStorage<ShlinkSessionData>,
   ) {}
 
   async login(request: Request): Promise<Response> {
     const [sessionData, session] = await Promise.all([
       this.authenticator.authenticate(CREDENTIALS_STRATEGY, request),
-      this.sessionStorage.getSession(request.headers.get('cookie')),
+      this.sessionFromRequest(request),
     ]);
     session.set('sessionData', sessionData);
 
@@ -30,7 +30,7 @@ export class AuthHelper {
   }
 
   async logout(request: Request): Promise<Response> {
-    const session = await this.sessionStorage.getSession(request.headers.get('cookie'));
+    const session = await this.sessionFromRequest(request);
     return redirect('/login', {
       headers: { 'Set-Cookie': await this.sessionStorage.destroySession(session) },
     });
@@ -39,14 +39,33 @@ export class AuthHelper {
   async getSession(request: Request): Promise<SessionData | undefined>;
   async getSession(request: Request, redirectTo: string): Promise<SessionData>;
   async getSession(request: Request, redirectTo?: string): Promise<SessionData | undefined> {
-    const session = await this.sessionStorage.getSession(request.headers.get('cookie'));
-    const sessionData = session.get('sessionData');
-
+    const [sessionData] = await this.sessionAndData(request);
     if (redirectTo && !sessionData) {
       throw redirect(redirectTo);
     }
 
     return sessionData;
+  }
+
+  /**
+   * Refresh an active session expiration, to avoid expiring cookies for users which are active in the app
+   */
+  async refreshSessionExpiration(request: Request): Promise<string | undefined> {
+    const [sessionData, session] = await this.sessionAndData(request);
+    if (sessionData) {
+      return await this.sessionStorage.commitSession(session);
+    }
+
+    return undefined;
+  }
+
+  private sessionFromRequest(request: Request): Promise<Session<ShlinkSessionData>> {
+    return this.sessionStorage.getSession(request.headers.get('cookie'));
+  }
+
+  private async sessionAndData(request: Request): Promise<[SessionData | undefined, Session<ShlinkSessionData>]> {
+    const session = await this.sessionFromRequest(request);
+    return [session.get('sessionData'), session];
   }
 
   async isAuthenticated(request: Request): Promise<boolean> {

--- a/app/auth/session-context.ts
+++ b/app/auth/session-context.ts
@@ -3,6 +3,10 @@ import { createContext, useContext } from 'react';
 export type SessionData = {
   userId: string;
   displayName: string | null;
+};
+
+export type ShlinkSessionData = {
+  sessionData: SessionData;
   [key: string]: unknown;
 };
 

--- a/app/auth/session.server.ts
+++ b/app/auth/session.server.ts
@@ -1,8 +1,8 @@
 import { createCookieSessionStorage } from 'react-router';
 import { env, isProd } from '../utils/env.server';
-import type { SessionData } from './session-context';
+import type { ShlinkSessionData } from './session-context';
 
-export const createSessionStorage = () => createCookieSessionStorage<{ sessionData: SessionData }>({
+export const createSessionStorage = () => createCookieSessionStorage<ShlinkSessionData>({
   cookie: {
     name: 'shlink_dashboard_session',
     httpOnly: true,
@@ -13,5 +13,3 @@ export const createSessionStorage = () => createCookieSessionStorage<{ sessionDa
     secure: isProd(),
   },
 });
-
-export type SessionStorage = ReturnType<typeof createSessionStorage>;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -2,6 +2,7 @@ import type { Theme } from '@shlinkio/shlink-frontend-kit';
 import { getSystemPreferredTheme } from '@shlinkio/shlink-frontend-kit';
 import { useEffect, useState } from 'react';
 import type { LoaderFunctionArgs } from 'react-router';
+import { data } from 'react-router';
 import { Links, Meta, Outlet, Scripts, useLoaderData } from 'react-router';
 import { AuthHelper } from './auth/auth-helper.server';
 import { SessionProvider } from './auth/session-context';
@@ -24,8 +25,14 @@ export async function loader(
   );
 
   const settings = sessionData && (await settingsService.userSettings(sessionData.userId));
+  const sessionCookie = await authHelper.refreshSessionExpiration(request);
 
-  return { sessionData, settings };
+  return data(
+    { sessionData, settings },
+    sessionCookie ? {
+      headers: { 'Set-Cookie': sessionCookie },
+    } : undefined,
+  );
 }
 
 export default function App() {


### PR DESCRIPTION
Closes #82 

Commit the session on every request, so that active users do not get their session expired until they have been inactive for the total session duration (currently 30min) 