### PR TITLE
Ensure tests, scripts and config files are linted

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,10 +1,12 @@
 import shlink from '@shlinkio/eslint-config-js-coding-standard';
 
-/* eslint-disable-next-line no-restricted-exports */
+// eslint-disable-next-line no-restricted-exports
 export default [
   ...shlink,
   {
-    files: ['**/app/routes/**', '**/app/root.tsx', 'vite*.config.ts'],
+    // Allow config files and route files to have a default export, as that's what the third parties consuming them
+    // expect
+    files: ['**/app/routes/**', '**/app/root.tsx', '*.config.ts'],
     rules: {
       'no-restricted-exports': 'off',
     },

--- a/mikro-orm.config.ts
+++ b/mikro-orm.config.ts
@@ -55,5 +55,4 @@ async function resolveOptions(): Promise<Options> {
   };
 }
 
-// eslint-disable-next-line no-restricted-exports
 export default await resolveOptions();

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run",
     "test:ci": "npm run test -- --coverage",
     "lint": "npm run lint:js",
-    "lint:js": "eslint app",
+    "lint:js": "eslint app scripts test server.ts *.config.ts",
     "lint:fix": "npm run lint:js:fix",
     "lint:js:fix": "npm run lint:js -- --fix",
     "types": "react-router typegen && tsc",

--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -1,4 +1,3 @@
 import type { Config } from '@react-router/dev/config';
 
-// eslint-disable-next-line no-restricted-exports
 export default {} satisfies Config;

--- a/test/routes/_index/ServersList.test.tsx
+++ b/test/routes/_index/ServersList.test.tsx
@@ -9,7 +9,7 @@ describe('<ServersList />', () => {
   const setUp = (servers: Server[]) => render(
     <MemoryRouter>
       <ServersList servers={servers} />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 
   it('passes a11y checks', () => checkAccessibility(setUp([

--- a/test/routes/_index/WelcomeCard.test.tsx
+++ b/test/routes/_index/WelcomeCard.test.tsx
@@ -9,7 +9,7 @@ describe('<WelcomeCard />', () => {
   const setUp = (servers: Server[]) => render(
     <MemoryRouter>
       <WelcomeCard servers={servers} />
-    </MemoryRouter>
+    </MemoryRouter>,
   );
 
   it('passes a11y checks', () => checkAccessibility(setUp([])));

--- a/test/routes/_index/route.test.tsx
+++ b/test/routes/_index/route.test.tsx
@@ -1,6 +1,6 @@
-import { createRoutesStub } from 'react-router';
 import { render, screen, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
+import { createRoutesStub } from 'react-router';
 import type { AuthHelper } from '../../../app/auth/auth-helper.server';
 import type { SessionData } from '../../../app/auth/session-context';
 import type { Server } from '../../../app/entities/Server';


### PR DESCRIPTION
Improve the command running eslint so that it covers tests, scripts and config files, as well as application code.