### PR TITLE
Allow users table to be ordered by clicking the table headers

### DIFF
--- a/app/fe-kit/Paginator.tsx
+++ b/app/fe-kit/Paginator.tsx
@@ -9,10 +9,10 @@ import { ELLIPSIS, keyForPage, pageIsEllipsis, prettifyPageNumber, progressivePa
 
 const buildPaginatorItemClasses = (active = false) => clsx(
   'tw:border-r tw:last:border-none',
-  'tw:px-3 py-2 tw:cursor-pointer tw:!no-underline',
+  'tw:px-3 py-2 tw:cursor-pointer tw:no-underline!',
   {
     'tw:hover:bg-(--secondary-color) tw:text-shlink-brand tw:border-r-(--border-color)': !active,
-    'tw:bg-(--brand-color) tw:!text-white tw:border-r-(--brand-color)': active,
+    'tw:bg-(--brand-color) tw:text-white! tw:border-r-(--brand-color)': active,
   },
 );
 

--- a/app/fe-kit/Table.tsx
+++ b/app/fe-kit/Table.tsx
@@ -27,7 +27,7 @@ const Row: FC<HTMLProps<HTMLTableRowElement>> = ({ children, className, ...rest 
   const sectionContext = useContext(TableSectionContext);
   return (
     <tr
-      className={clsx(
+      className={clsx('tw:group',
         {
           'tw:hover:bg-(--secondary-color)': sectionContext?.section === 'body',
         },
@@ -45,7 +45,18 @@ const Cell: FC<HTMLProps<HTMLTableCellElement>> = ({ children, className, ...res
   const Tag = sectionContext?.section === 'head' ? 'th' : 'td';
 
   return (
-    <Tag className={clsx('tw:p-2 tw:!border-b-1 tw:!border-(--border-color)', className)} {...rest}>
+    <Tag
+      className={clsx(
+        'tw:p-2 tw:border-(--border-color)!',
+        {
+          // For non-header cells, add a bottom border only when not part of the last row
+          'tw:group-[&:not(:last-child)]:border-b-1!': Tag === 'td',
+          'tw:border-b-1!': Tag === 'th',
+        },
+        className,
+      )}
+      {...rest}
+    >
       {children}
     </Tag>
   );

--- a/app/routes/index/WelcomeCard.tsx
+++ b/app/routes/index/WelcomeCard.tsx
@@ -19,7 +19,7 @@ export const WelcomeCard: FC<WelcomeCardProps> = ({ servers }) => (
       <ShlinkLogo />
     </div>
     <div className="tw:md:w-8/12 tw:w-full">
-      <h1 className="tw:px-5 tw:py-6 tw:text-center tw:border-b tw:border-b-(--border-color)">Welcome!</h1>
+      <h1 className="tw:px-5 tw:py-6 tw:!mb-0 tw:text-center tw:border-b tw:border-b-(--border-color)">Welcome!</h1>
       {servers.length > 0 ? <ServersList servers={servers} /> : <NoServers />}
     </div>
   </SimpleCard>

--- a/app/routes/index/WelcomeCard.tsx
+++ b/app/routes/index/WelcomeCard.tsx
@@ -19,7 +19,7 @@ export const WelcomeCard: FC<WelcomeCardProps> = ({ servers }) => (
       <ShlinkLogo />
     </div>
     <div className="tw:md:w-8/12 tw:w-full">
-      <h1 className="tw:px-5 tw:py-6 tw:!mb-0 tw:text-center tw:border-b tw:border-b-(--border-color)">Welcome!</h1>
+      <h1 className="tw:px-5 tw:py-6 tw:mb-0! tw:text-center tw:border-b tw:border-b-(--border-color)">Welcome!</h1>
       {servers.length > 0 ? <ServersList servers={servers} /> : <NoServers />}
     </div>
   </SimpleCard>

--- a/app/routes/users/manage-users.tsx
+++ b/app/routes/users/manage-users.tsx
@@ -6,8 +6,7 @@ import { determineOrderDir, SimpleCard, stringToOrder } from '@shlinkio/shlink-f
 import type { PropsWithChildren } from 'react';
 import { useCallback } from 'react';
 import type { LoaderFunctionArgs } from 'react-router';
-import { useParams } from 'react-router';
-import { useLoaderData } from 'react-router';
+import { href, useLoaderData,useParams } from 'react-router';
 import { AuthHelper } from '../../auth/auth-helper.server';
 import { Layout } from '../../common/Layout';
 import { serverContainer } from '../../container/container.server';
@@ -71,7 +70,7 @@ export default function ManageUsers() {
     }
 
     const queryString = query.size > 0 ? `?${query.toString()}` : '';
-    return `/users/manage/${page}${queryString}`;
+    return href(`/users/manage/:page${queryString}`, { page: `${page}` });
   }, [dir, field]);
 
   return (

--- a/app/routes/users/manage-users.tsx
+++ b/app/routes/users/manage-users.tsx
@@ -47,7 +47,7 @@ function determineOrder(
 function HeaderCell({ orderDir, href, children }: PropsWithChildren<{ orderDir: OrderDir; href: string }>) {
   return (
     <Table.Cell>
-      <a className="tw:!text-current" href={href}>
+      <a className="tw:text-current!" href={href}>
         {children}
       </a>
       {orderDir && (

--- a/app/users/UsersService.server.ts
+++ b/app/users/UsersService.server.ts
@@ -1,16 +1,14 @@
 import type { EntityManager } from '@mikro-orm/core';
+import type { Order } from '@shlinkio/shlink-frontend-kit';
 import { verifyPassword } from '../auth/passwords.server';
 import type { User } from '../entities/User';
 import { User as UserEntity } from '../entities/User';
 
-type OrderableFields = keyof Omit<User, 'id' | 'password'>;
+export type UserOrderableFields = keyof Omit<User, 'id' | 'password'>;
 
 export type ListUsersOptions = {
   page?: number;
-  orderBy?: {
-    field: OrderableFields,
-    direction?: 'ASC' | 'DESC',
-  };
+  orderBy?: Order<UserOrderableFields>;
 };
 
 export type UsersList = {
@@ -36,10 +34,7 @@ export class UsersService {
     return user;
   }
 
-  async listUsers({
-    page = 1,
-    orderBy = { field: 'createdAt' },
-  }: ListUsersOptions): Promise<UsersList> {
+  async listUsers({ page = 1, orderBy }: ListUsersOptions): Promise<UsersList> {
     const positivePage = Math.max(1, page);
     const limit = 20;
     const offset = (positivePage - 1) * limit;
@@ -48,7 +43,7 @@ export class UsersService {
       limit,
       offset,
       orderBy: {
-        [orderBy.field]: orderBy.direction ?? 'ASC',
+        [orderBy?.field ?? 'createdAt']: orderBy?.dir ?? 'ASC',
       },
     });
 

--- a/test/routes/index/home.test.tsx
+++ b/test/routes/index/home.test.tsx
@@ -38,6 +38,7 @@ describe('home', () => {
         {
           path: '/',
           Component: Home,
+          HydrateFallback: () => null,
           loader: () => ({ servers }),
         },
       ]);

--- a/test/routes/login.test.tsx
+++ b/test/routes/login.test.tsx
@@ -65,6 +65,7 @@ describe('login', () => {
         {
           path: '/',
           Component: Login,
+          HydrateFallback: () => null,
           action: () => ({ error }),
         },
       ]);

--- a/test/routes/settings.test.tsx
+++ b/test/routes/settings.test.tsx
@@ -64,6 +64,7 @@ describe('settings', () => {
         {
           path: '/settings/general',
           Component: SettingsComp,
+          HydrateFallback: () => null,
           loader: () => ({}),
           action: () => ({}),
         },

--- a/test/routes/users/manage-users.test.tsx
+++ b/test/routes/users/manage-users.test.tsx
@@ -1,5 +1,5 @@
 import type { Order } from '@shlinkio/shlink-frontend-kit';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { LoaderFunctionArgs } from 'react-router';
 import { createRoutesStub } from 'react-router';
@@ -36,11 +36,12 @@ describe('manage-users', () => {
       listUsers.mockResolvedValue(fromPartial({}));
 
       await runLoader({
+        request: fromPartial({ url: 'https://example.com' }),
         params: { page: '5' },
       });
 
       expect(getSession).toHaveBeenCalled();
-      expect(listUsers).toHaveBeenCalledWith({ page: 5 });
+      expect(listUsers).toHaveBeenCalledWith(expect.objectContaining({ page: 5 }));
     });
   });
 
@@ -51,46 +52,112 @@ describe('manage-users', () => {
       orderBy?: Order<UserOrderableFields>;
     };
 
-    const setUp = ({ users = [], totalPages = 1, orderBy = {} }: SetUpOptions = {}) => {
+    const setUp = async ({ users = [], totalPages = 1, orderBy = {} }: SetUpOptions = {}) => {
       const Stub = createRoutesStub([
         {
           path: '/users/manage/1',
           Component: ManageUsers,
-          loader: () => ({ users, totalPages, orderBy }),
+          HydrateFallback: () => null,
+          loader: () => ({ users, totalPages, orderBy, currentPage: 1 }),
         },
       ]);
-      return render(<Stub initialEntries={['/users/manage/1']} />);
+      const renderResult = render(<Stub initialEntries={['/users/manage/1']} />);
+
+      // Wait for the table to be rendered
+      await screen.findByRole('table');
+
+      return renderResult;
     };
 
     it.each([
       {},
       { users: [mockUser({ username: 'foo', displayName: 'John Doe', role: 'admin' })] },
       { totalPages: 5 },
-    ])('passes a11y checks', async ({ users, totalPages }) => {
-      const { container } = setUp({ users, totalPages });
-
-      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
-      await checkAccessibility({ container });
-    });
+    ])('passes a11y checks', async ({ users, totalPages }) => checkAccessibility(setUp({ users, totalPages })));
 
     it('renders empty users list if no users are returned', async () => {
-      setUp();
+      await setUp();
 
-      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
       expect(screen.getByText('No users found')).toBeInTheDocument();
       expect(screen.queryByTestId('paginator')).not.toBeInTheDocument();
     });
 
     it('renders list with returned users', async () => {
-      setUp({
+      await setUp({
         users: [mockUser({ username: 'foo', displayName: 'John Doe', role: 'admin' })],
         totalPages: 5,
       });
 
-      await waitFor(() => expect(screen.getByRole('table')).toBeInTheDocument());
       expect(screen.queryByText('No users found')).not.toBeInTheDocument();
       expect(screen.getByText('John Doe')).toBeInTheDocument();
       expect(screen.getByTestId('paginator')).toBeInTheDocument();
+    });
+
+    it.each([
+      { orderBy: undefined, expectedOrderedColumn: 'Created' },
+      {
+        orderBy: { field: 'createdAt' as const },
+        expectedOrderedColumn: 'Created',
+      },
+      {
+        orderBy: { field: 'username' as const, dir: 'DESC' as const },
+        expectedOrderedColumn: 'Username',
+      },
+      {
+        orderBy: { field: 'displayName' as const, dir: 'ASC' as const },
+        expectedOrderedColumn: 'Display name',
+      },
+      {
+        orderBy: { field: 'role' as const, dir: 'ASC' as const },
+        expectedOrderedColumn: 'Role',
+      },
+    ])('marks expected column as ordered', async ({ orderBy, expectedOrderedColumn }) => {
+      await setUp({ orderBy });
+      const column = screen.getByText(expectedOrderedColumn);
+
+      expect(column.parentElement?.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it.each([
+      {
+        orderBy: undefined,
+        expectedUrls: {
+          'Created': 'orderBy=createdAt-DESC',
+          'Username': 'orderBy=username-ASC',
+          'Display name': 'orderBy=displayName-ASC',
+          'Role': 'orderBy=role-ASC',
+        },
+      },
+      {
+        orderBy: {
+          field: 'username' as const,
+          dir: 'DESC' as const,
+        },
+        expectedUrls: {
+          'Created': 'orderBy=createdAt-ASC',
+          // 'Username': 'orderBy=username-ASC', TODO Fix this
+          'Display name': 'orderBy=displayName-ASC',
+          'Role': 'orderBy=role-ASC',
+        },
+      },
+      {
+        orderBy: {
+          field: 'displayName' as const,
+          dir: 'ASC' as const,
+        },
+        expectedUrls: {
+          'Created': 'orderBy=createdAt-ASC',
+          'Username': 'orderBy=username-ASC',
+          'Display name': 'orderBy=displayName-DESC',
+          'Role': 'orderBy=role-ASC',
+        },
+      },
+    ])('includes order in header URLs', async ({ orderBy, expectedUrls }) => {
+      await setUp({ totalPages: 10, orderBy });
+
+      Object.entries(expectedUrls).forEach(([linkText, expectedUrl]) => {
+        expect(screen.getByRole('link', { name: linkText })).toHaveAttribute('href', `/users/manage/1?${expectedUrl}`);
+      });
     });
   });
 });

--- a/test/users/UsersService.server.test.ts
+++ b/test/users/UsersService.server.test.ts
@@ -92,5 +92,28 @@ describe('UsersService', () => {
       expect(result.totalUsers).toEqual(totalUsers);
       expect(result.totalPages).toEqual(expectedTotalPages);
     });
+
+    it.each([
+      {
+        orderBy: undefined,
+        expectedOrderBy: { createdAt: 'ASC' },
+      },
+      {
+        orderBy: { field: 'createdAt' as const, dir: 'ASC' as const },
+        expectedOrderBy: { createdAt: 'ASC' },
+      },
+      {
+        orderBy: { field: 'username' as const, dir: 'DESC' as const },
+        expectedOrderBy: { username: 'DESC' },
+      },
+    ])('orders by expected field', async ({ orderBy, expectedOrderBy }) => {
+      findAndCount.mockResolvedValue([[], 0]);
+
+      await usersService.listUsers({ orderBy });
+
+      expect(findAndCount).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.objectContaining({
+        orderBy: expectedOrderBy,
+      }));
+    });
   });
 });


### PR DESCRIPTION
Part of #6 

Allow users table headers to be clicked in order to determine the field and direction from which the list of users should be ordered.