### PR TITLE
Rearrange menu to collapse all user-specific options under a user menu

### DIFF
--- a/app/auth/auth.server.ts
+++ b/app/auth/auth.server.ts
@@ -12,13 +12,13 @@ function getAuthStrategies(usersService: UsersService): Map<string, Strategy<Ses
 
   // Add strategy to login via credentials form
   strategies.set(CREDENTIALS_STRATEGY, new FormStrategy(async ({ form }): Promise<SessionData> => {
-    const { username, password } = credentialsSchema.parse({
+    const { username: providedUsername, password } = credentialsSchema.parse({
       username: form.get('username'),
       password: form.get('password'),
     });
 
-    const { id, displayName, role } = await usersService.getUserByCredentials(username, password);
-    return { userId: id.toString(), displayName, role };
+    const { id, displayName, role, username } = await usersService.getUserByCredentials(providedUsername, password);
+    return { userId: id.toString(), displayName, role, username };
   }));
 
   // TODO Add other strategies, like oAuth for SSO

--- a/app/auth/session-context.ts
+++ b/app/auth/session-context.ts
@@ -4,6 +4,7 @@ import type { Role } from '../entities/User';
 export type SessionData = {
   userId: string;
   displayName: string | null;
+  username: string;
   role: Role;
 };
 

--- a/app/common/MainHeader.tsx
+++ b/app/common/MainHeader.tsx
@@ -2,13 +2,26 @@ import {
   faArrowRightFromBracket as faLogout,
   faChevronDown as arrowIcon,
   faCogs,
+  faUser,
   faUsers,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useToggle } from '@shlinkio/shlink-frontend-kit';
 import type { FC } from 'react';
 import { Link, useLocation } from 'react-router';
-import { Collapse, Nav, Navbar, NavbarBrand, NavbarToggler, NavItem, NavLink } from 'reactstrap';
+import {
+  Collapse,
+  DropdownItem,
+  DropdownMenu,
+  DropdownToggle,
+  Nav,
+  Navbar,
+  NavbarBrand,
+  NavbarToggler,
+  NavItem,
+  NavLink,
+  UncontrolledDropdown,
+} from 'reactstrap';
 import { useSession } from '../auth/session-context';
 import { ShlinkLogo } from './ShlinkLogo';
 
@@ -31,26 +44,27 @@ export const MainHeader: FC = () => {
 
           <Collapse navbar isOpen={isOpen}>
             <Nav navbar className="tw:ml-auto">
-              <NavItem>
-                <NavLink tag={Link} to="/settings" active={pathname.startsWith('/settings')}>
-                  <FontAwesomeIcon icon={faCogs} className="tw:mr-0.5" /> Settings
-                </NavLink>
-              </NavItem>
               {session.role === 'admin' && (
                 <NavItem>
-                  <NavLink tag={Link} to="/users/manage/1" active={pathname.startsWith('/users/manage')}>
+                  <NavLink tag={Link} to="/manage-users/1" active={pathname.startsWith('/manage-users')}>
                     <FontAwesomeIcon icon={faUsers} className="tw:mr-0.5" /> Manage users
                   </NavLink>
                 </NavItem>
               )}
-              <NavItem>
-                <NavLink tag={Link} to="/logout">
-                  <FontAwesomeIcon icon={faLogout} className="tw:mr-0.5" /> Logout
-                  {session.displayName && (
-                    <span className="tw:ml-2" data-testid="display-name">({session.displayName})</span>
-                  )}
-                </NavLink>
-              </NavItem>
+              <UncontrolledDropdown nav inNavbar>
+                <DropdownToggle nav caret tag="button" data-testid="display-name">
+                  <FontAwesomeIcon icon={faUser} fixedWidth /> {session.displayName ?? session.username}
+                </DropdownToggle>
+                <DropdownMenu end>
+                  <DropdownItem tag={Link} to="/settings" active={pathname.startsWith('/settings')}>
+                    <FontAwesomeIcon icon={faCogs} fixedWidth className="tw:mr-0.5" /> Settings
+                  </DropdownItem>
+                  <DropdownItem divider tag="hr" />
+                  <DropdownItem tag={Link} to="/logout">
+                    <FontAwesomeIcon icon={faLogout} fixedWidth className="tw:mr-0.5" /> Logout
+                  </DropdownItem>
+                </DropdownMenu>
+              </UncontrolledDropdown>
             </Nav>
           </Collapse>
         </>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -13,7 +13,7 @@ export default [
   route('/server/:serverId/*', './routes/shlink-component-wrapper.tsx'),
 
   // Users management
-  route('/users/manage/:page', './routes/users/manage-users.tsx'),
+  route('/manage-users/:page', './routes/users/manage-users.tsx'),
 
   // TODO Servers management
 ] satisfies RouteConfig;

--- a/app/routes/users/manage-users.tsx
+++ b/app/routes/users/manage-users.tsx
@@ -68,7 +68,7 @@ export default function ManageUsers() {
       query.set('orderBy', orderToString({ field, dir: dir ?? 'ASC' }) ?? '');
     }
     const queryString = query.size > 0 ? `?${query.toString()}` : '';
-    const baseUrl = href('/users/manage/:page', { page: `${page}` });
+    const baseUrl = href('/manage-users/:page', { page: `${page}` });
 
     return `${baseUrl}${queryString}`;
   }, [dir, field]);

--- a/test/common/MainHeader.test.tsx
+++ b/test/common/MainHeader.test.tsx
@@ -7,8 +7,8 @@ import { MainHeader } from '../../app/common/MainHeader';
 import { checkAccessibility } from '../__helpers__/accessibility';
 
 describe('<MainHeader />', () => {
-  const setUp = (session?: SessionData) => render(
-    <SessionProvider value={session ?? null}>
+  const setUp = (session: SessionData | null = null) => render(
+    <SessionProvider value={session}>
       <MemoryRouter>
         <MainHeader />
       </MemoryRouter>
@@ -16,38 +16,29 @@ describe('<MainHeader />', () => {
   );
 
   it.each([
-    [undefined],
-    [fromPartial<SessionData>({})],
+    [fromPartial<SessionData>({ displayName: 'Jane' })],
+    [fromPartial<SessionData>({ username: 'jane' })],
   ])('passes a11y checks', (session) => checkAccessibility(setUp(session)));
 
   it.each([
     [undefined],
-    [fromPartial<SessionData>({})],
-  ])('shows logout and menu toggle only if session is set', (session) => {
+    [fromPartial<SessionData>({ displayName: 'Jane Doe' })],
+  ])('shows user menu toggle only if session is set', (session) => {
     setUp(session);
 
     if (session) {
-      expect(screen.getByRole('button')).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Logout' })).toBeInTheDocument();
-      expect(screen.getByRole('link', { name: 'Settings' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Jane Doe' })).toBeInTheDocument();
     } else {
       expect(screen.queryByRole('button')).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Logout' })).not.toBeInTheDocument();
-      expect(screen.queryByRole('link', { name: 'Settings' })).not.toBeInTheDocument();
     }
   });
 
   it.each([
-    [fromPartial<SessionData>({})],
+    [fromPartial<SessionData>({ username: 'jane_doe' })],
     [fromPartial<SessionData>({ displayName: 'Jane Doe' })],
   ])('shows display name only if not null', (session) => {
     setUp(session);
-
-    if (session.displayName) {
-      expect(screen.getByTestId('display-name')).toHaveTextContent(`(${session.displayName})`);
-    } else {
-      expect(screen.queryByTestId('display-name')).not.toBeInTheDocument();
-    }
+    expect(screen.getByTestId('display-name')).toHaveTextContent(session.displayName ?? session.username);
   });
 
   it.each([

--- a/test/routes/users/manage-users.test.tsx
+++ b/test/routes/users/manage-users.test.tsx
@@ -55,13 +55,13 @@ describe('manage-users', () => {
     const setUp = async ({ users = [], totalPages = 1, orderBy = {} }: SetUpOptions = {}) => {
       const Stub = createRoutesStub([
         {
-          path: '/users/manage/1',
+          path: '/manage-users/1',
           Component: ManageUsers,
           HydrateFallback: () => null,
           loader: () => ({ users, totalPages, orderBy, currentPage: 1 }),
         },
       ]);
-      const renderResult = render(<Stub initialEntries={['/users/manage/1']} />);
+      const renderResult = render(<Stub initialEntries={['/manage-users/1']} />);
 
       // Wait for the table to be rendered
       await screen.findByRole('table');
@@ -156,7 +156,7 @@ describe('manage-users', () => {
       await setUp({ totalPages: 10, orderBy });
 
       Object.entries(expectedUrls).forEach(([linkText, expectedUrl]) => {
-        expect(screen.getByRole('link', { name: linkText })).toHaveAttribute('href', `/users/manage/1?${expectedUrl}`);
+        expect(screen.getByRole('link', { name: linkText })).toHaveAttribute('href', `/manage-users/1?${expectedUrl}`);
       });
     });
   });


### PR DESCRIPTION
Part of #6 

Reorder menu so that settings and logout options are displayed under a user dropdown menu.

Before:

![image](https://github.com/user-attachments/assets/1658b1d5-fa52-429e-952a-4d437dfc2436)

After:

![image](https://github.com/user-attachments/assets/ffe248db-8b89-43b8-aa3c-2369719f1b3b)
