### PR TITLE
Add advanced and managed user roles

### DIFF
--- a/app/entities/User.ts
+++ b/app/entities/User.ts
@@ -1,7 +1,7 @@
 import { EntitySchema } from '@mikro-orm/core';
 import { BaseEntity, idColumnSchema } from './Base';
 
-const roles = ['admin', 'user'] as const;
+const roles = ['admin', 'advanced-user', 'managed-user'] as const;
 
 export type Role = typeof roles[number];
 

--- a/app/routes/users/RoleBadge.tsx
+++ b/app/routes/users/RoleBadge.tsx
@@ -11,10 +11,10 @@ export const RoleBadge: FC<RoleBadgeProps> = ({ role }) => {
     <div
       className={clsx('tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold', {
         'tw:bg-green-600 tw:text-white': role === 'admin',
-        'tw:bg-gray-500 tw:text-white': role === 'user',
+        'tw:bg-gray-500 tw:text-white': role !== 'admin',
       })}
     >
-      {role}
+      {role.replaceAll('-', ' ')}
     </div>
   );
 };

--- a/test/common/MainHeader.test.tsx
+++ b/test/common/MainHeader.test.tsx
@@ -43,7 +43,8 @@ describe('<MainHeader />', () => {
 
   it.each([
     { sessionData: fromPartial<SessionData>({ role: 'admin' }), shouldShowUsersMenu: true },
-    { sessionData: fromPartial<SessionData>({ role: 'user' }), shouldShowUsersMenu: false },
+    { sessionData: fromPartial<SessionData>({ role: 'advanced-user' }), shouldShowUsersMenu: false },
+    { sessionData: fromPartial<SessionData>({ role: 'managed-user' }), shouldShowUsersMenu: false },
   ])('shows user management option for admins', ({ sessionData, shouldShowUsersMenu }) => {
     setUp(sessionData);
 

--- a/test/routes/users/RoleBadge.test.tsx
+++ b/test/routes/users/RoleBadge.test.tsx
@@ -7,7 +7,8 @@ describe('<RoleBadge />', () => {
   const setUp = (role: Role) => render(<RoleBadge role={role} />);
   const testCases = [
     { role: 'admin' as const },
-    { role: 'user' as const },
+    { role: 'advanced-user' as const },
+    { role: 'managed-user' as const },
   ];
 
   it.each(testCases)('passes a11y checks', ({ role }) => checkAccessibility(setUp(role)));

--- a/test/routes/users/__snapshots__/RoleBadge.test.tsx.snap
+++ b/test/routes/users/__snapshots__/RoleBadge.test.tsx.snap
@@ -15,7 +15,17 @@ exports[`<RoleBadge /> > renders expected markup 2`] = `
   <div
     class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:bg-gray-500 tw:text-white"
   >
-    user
+    advanced user
+  </div>
+</div>
+`;
+
+exports[`<RoleBadge /> > renders expected markup 3`] = `
+<div>
+  <div
+    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:bg-gray-500 tw:text-white"
+  >
+    managed user
   </div>
 </div>
 `;


### PR DESCRIPTION
Part of #6 

Add more user roles to allow advanced users that can manage their own Shlink servers, and managed users that can only interact with Shlink servers that were previously created for them.

This will allow an admin to create a server using an API key with more restricted roles, and then a user would have limited permissions when interacting with links.

In future this would also potentially allow to add predefined parameters when creating or listing short URLs or visits, narrowing down what the user can see or do.