### PR TITLE
Allow existing users to be edited

### DIFF
--- a/app/db/BaseEntityRepository.ts
+++ b/app/db/BaseEntityRepository.ts
@@ -1,0 +1,7 @@
+import { EntityRepository } from '@mikro-orm/core';
+
+export abstract class BaseEntityRepository<Entity extends object> extends EntityRepository<Entity> {
+  async flush(): Promise<void> {
+    await this.em.flush();
+  }
+}

--- a/app/fe-kit/Label.tsx
+++ b/app/fe-kit/Label.tsx
@@ -2,17 +2,11 @@ import type { FC, HTMLProps } from 'react';
 
 export type LabelProps = HTMLProps<HTMLLabelElement> & {
   required?: boolean;
-
-  /**
-   * If set to true, it hides the asterisk that would be displayed when `required` is true.
-   * Defaults to `false`.
-   */
-  hiddenRequired?: boolean;
 };
 
-export const Label: FC<LabelProps> = ({ required, hiddenRequired = false, children, ...rest }) => (
+export const Label: FC<LabelProps> = ({ required, children, ...rest }) => (
   <label {...rest}>
     {children}
-    {required && !hiddenRequired && <span className="tw:text-danger tw:ml-1">*</span>}
+    {required && <span className="tw:text-danger tw:ml-1">*</span>}
   </label>
 );

--- a/app/fe-kit/LabelledInput.tsx
+++ b/app/fe-kit/LabelledInput.tsx
@@ -19,7 +19,7 @@ export const LabelledInput: FC<LabelledInputProps> = (
   const id = useId();
   return (
     <div className="tw:flex tw:flex-col tw:gap-1">
-      <Label htmlFor={id} required={required} hiddenRequired={hiddenRequired}>{label}</Label>
+      <Label htmlFor={id} required={required}>{label}</Label>
       <Input
         id={id}
         className={inputClassName}

--- a/app/fe-kit/LabelledSelect.tsx
+++ b/app/fe-kit/LabelledSelect.tsx
@@ -8,16 +8,18 @@ export type LabelledSelectProps = Omit<SelectProps, 'className' | 'id'> & {
   label: string;
   selectClassName?: string;
 
-  /** Same as required, but it will not cause a red asterisk to be added */
-  lightRequired?: boolean;
+  /** Alternative to `required`. Causes the input to be required, without displaying an asterisk */
+  hiddenRequired?: boolean;
 };
 
-export const LabelledSelect: FC<LabelledSelectProps> = ({ selectClassName, label, required, ...rest }) => {
+export const LabelledSelect: FC<LabelledSelectProps> = (
+  { selectClassName, label, required, hiddenRequired, ...rest },
+) => {
   const id = useId();
   return (
     <div className="tw:flex tw:flex-col tw:gap-1">
       <Label htmlFor={id} required={required}>{label}</Label>
-      <Select id={id} className={selectClassName} required={required} {...rest} />
+      <Select id={id} className={selectClassName} required={required || hiddenRequired} {...rest} />
     </div>
   );
 };

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -15,6 +15,7 @@ export default [
   // Users management
   route('/manage-users/create', './routes/users/create-user.tsx'),
   route('/manage-users/delete', './routes/users/delete-user.ts'),
+  route('/manage-users/edit/:userId', './routes/users/edit-user.tsx'),
   route('/manage-users/:page', './routes/users/manage-users.tsx'),
 
   // TODO Servers management

--- a/app/routes/users/RoleBadge.tsx
+++ b/app/routes/users/RoleBadge.tsx
@@ -9,10 +9,13 @@ export type RoleBadgeProps = {
 export const RoleBadge: FC<RoleBadgeProps> = ({ role }) => {
   return (
     <div
-      className={clsx('tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold', {
-        'tw:bg-green-600 tw:text-white': role === 'admin',
-        'tw:bg-gray-500 tw:text-white': role !== 'admin',
-      })}
+      className={clsx(
+        'tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:whitespace-nowrap',
+        {
+          'tw:bg-green-600 tw:text-white': role === 'admin',
+          'tw:bg-gray-500 tw:text-white': role !== 'admin',
+        },
+      )}
     >
       {role.replaceAll('-', ' ')}
     </div>

--- a/app/routes/users/UserFormFields.tsx
+++ b/app/routes/users/UserFormFields.tsx
@@ -7,15 +7,19 @@ import { SimpleCard } from '../../fe-kit/SimpleCard';
 
 export type UserFormFieldsProps = {
   title: string;
-  user?: User;
   submitText: string;
-  disabled: boolean;
+  disabled?: boolean;
   usernameError?: string;
+
+  /** If provided, input values will be initialized with this user, and the username field will become readonly */
+  user?: User;
 };
 
 const roles = ['managed-user', 'advanced-user', 'admin'];
 
-export const UserFormFields: FC<UserFormFieldsProps> = ({ title, submitText, disabled, usernameError, user }) => {
+export const UserFormFields: FC<UserFormFieldsProps> = (
+  { title, submitText, disabled = false, usernameError, user },
+) => {
   const userIsReadonly = !!user;
 
   return (

--- a/app/routes/users/UserFormFields.tsx
+++ b/app/routes/users/UserFormFields.tsx
@@ -6,6 +6,7 @@ import { LabelledSelect } from '../../fe-kit/LabelledSelect';
 import { SimpleCard } from '../../fe-kit/SimpleCard';
 
 export type UserFormFieldsProps = {
+  title: string;
   user?: User;
   submitText: string;
   disabled: boolean;
@@ -14,32 +15,37 @@ export type UserFormFieldsProps = {
 
 const roles = ['managed-user', 'advanced-user', 'admin'];
 
-export const UserFormFields: FC<UserFormFieldsProps> = ({ submitText, disabled, usernameError, user }) => (
-  <div className="tw:flex tw:flex-col tw:gap-y-4">
-    <SimpleCard title="Add new user" bodyClassName="tw:flex tw:flex-col tw:gap-y-4">
-      <LabelledInput
-        label="Username"
-        name="username"
-        required
-        disabled={disabled}
-        readOnly={!!user}
-        error={usernameError}
-        defaultValue={user?.username}
-      />
-      <LabelledInput
-        label="Display name"
-        name="displayName"
-        disabled={disabled}
-        defaultValue={user?.displayName ?? undefined}
-        maxLength={255}
-      />
-      <LabelledSelect label="Role" name="role" required disabled={disabled} defaultValue={user?.role}>
-        {roles.map((role) => <option value={role} key={role}>{role.replaceAll('-', ' ')}</option>)}
-      </LabelledSelect>
-    </SimpleCard>
-    <div className="tw:flex tw:flex-row-reverse tw:gap-2">
-      <Button type="submit" disabled={disabled}>{submitText}</Button>
-      <Button variant="secondary" to="/manage-users/1">Cancel</Button>
+export const UserFormFields: FC<UserFormFieldsProps> = ({ title, submitText, disabled, usernameError, user }) => {
+  const userIsReadonly = !!user;
+
+  return (
+    <div className="tw:flex tw:flex-col tw:gap-y-4">
+      <SimpleCard title={title} bodyClassName="tw:flex tw:flex-col tw:gap-y-4">
+        <LabelledInput
+          label="Username"
+          // When username is readonly, do not set a name, so that it is not sent with the rest of the form
+          name={userIsReadonly ? undefined : 'username'}
+          readOnly={userIsReadonly}
+          disabled={disabled}
+          required
+          error={usernameError}
+          defaultValue={user?.username}
+        />
+        <LabelledInput
+          label="Display name"
+          name="displayName"
+          disabled={disabled}
+          defaultValue={user?.displayName ?? undefined}
+          maxLength={255}
+        />
+        <LabelledSelect label="Role" name="role" required disabled={disabled} defaultValue={user?.role}>
+          {roles.map((role) => <option value={role} key={role}>{role.replaceAll('-', ' ')}</option>)}
+        </LabelledSelect>
+      </SimpleCard>
+      <div className="tw:flex tw:flex-row-reverse tw:gap-2">
+        <Button type="submit" disabled={disabled}>{submitText}</Button>
+        <Button variant="secondary" to="/manage-users/1">Cancel</Button>
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/app/routes/users/UserFormFields.tsx
+++ b/app/routes/users/UserFormFields.tsx
@@ -1,0 +1,45 @@
+import type { FC } from 'react';
+import type { User } from '../../entities/User';
+import { Button } from '../../fe-kit/Button';
+import { LabelledInput } from '../../fe-kit/LabelledInput';
+import { LabelledSelect } from '../../fe-kit/LabelledSelect';
+import { SimpleCard } from '../../fe-kit/SimpleCard';
+
+export type UserFormFieldsProps = {
+  user?: User;
+  submitText: string;
+  disabled: boolean;
+  usernameError?: string;
+};
+
+const roles = ['managed-user', 'advanced-user', 'admin'];
+
+export const UserFormFields: FC<UserFormFieldsProps> = ({ submitText, disabled, usernameError, user }) => (
+  <div className="tw:flex tw:flex-col tw:gap-y-4">
+    <SimpleCard title="Add new user" bodyClassName="tw:flex tw:flex-col tw:gap-y-4">
+      <LabelledInput
+        label="Username"
+        name="username"
+        required
+        disabled={disabled}
+        readOnly={!!user}
+        error={usernameError}
+        defaultValue={user?.username}
+      />
+      <LabelledInput
+        label="Display name"
+        name="displayName"
+        disabled={disabled}
+        defaultValue={user?.displayName ?? undefined}
+        maxLength={255}
+      />
+      <LabelledSelect label="Role" name="role" required disabled={disabled} defaultValue={user?.role}>
+        {roles.map((role) => <option value={role} key={role}>{role.replaceAll('-', ' ')}</option>)}
+      </LabelledSelect>
+    </SimpleCard>
+    <div className="tw:flex tw:flex-row-reverse tw:gap-2">
+      <Button type="submit" disabled={disabled}>{submitText}</Button>
+      <Button variant="secondary" to="/manage-users/1">Cancel</Button>
+    </div>
+  </div>
+);

--- a/app/routes/users/create-user.tsx
+++ b/app/routes/users/create-user.tsx
@@ -6,15 +6,12 @@ import { AuthHelper } from '../../auth/auth-helper.server';
 import { Layout } from '../../common/Layout';
 import { serverContainer } from '../../container/container.server';
 import { Button } from '../../fe-kit/Button';
-import { LabelledInput } from '../../fe-kit/LabelledInput';
-import { LabelledSelect } from '../../fe-kit/LabelledSelect';
 import { SimpleCard } from '../../fe-kit/SimpleCard';
 import { UsersService } from '../../users/UsersService.server';
 import { DuplicatedEntryError } from '../../validation/DuplicatedEntryError.server';
 import { ValidationError } from '../../validation/ValidationError.server';
+import { UserFormFields } from './UserFormFields';
 import { ensureAdmin } from './utils';
-
-const roles = ['managed-user', 'advanced-user', 'admin'];
 
 export async function loader(
   { request }: LoaderFunctionArgs,
@@ -50,16 +47,16 @@ export async function action(
 export type ActionResult = Awaited<ReturnType<typeof action>>;
 
 export default function CreateUser() {
-  const { Form, ...fetcher } = useFetcher<ActionResult>();
-  const isSubmitting = fetcher.state === 'submitting';
+  const { Form, state, data } = useFetcher<ActionResult>();
+  const isSubmitting = state === 'submitting';
 
   return (
     <Layout>
-      {fetcher.data?.status === 'success' && (
+      {data?.status === 'success' && (
         <SimpleCard title="User created" bodyClassName="tw:flex tw:flex-col tw:gap-y-4" data-testid="success-message">
-          <p className="tw:m-0">User <b>{fetcher.data.user.username}</b> properly created.</p>
+          <p className="tw:m-0">User <b>{data.user.username}</b> properly created.</p>
           <p className="tw:m-0">
-            Their temporary password is <b>{fetcher.data.plainTextPassword}</b>. The user will have to change it the
+            Their temporary password is <b>{data.plainTextPassword}</b>. The user will have to change it the
             first time they log in.
           </p>
           <div>
@@ -67,27 +64,13 @@ export default function CreateUser() {
           </div>
         </SimpleCard>
       )}
-      {fetcher.data?.status !== 'success' && (
-        <Form method="post" className="tw:flex tw:flex-col tw:gap-y-4">
-          <SimpleCard title="Add new user" bodyClassName="tw:flex tw:flex-col tw:gap-y-4">
-            <LabelledInput
-              label="Username"
-              name="username"
-              required
-              disabled={isSubmitting}
-              error={fetcher.data?.status === 'error' ? fetcher.data?.messages.username : undefined}
-            />
-            <LabelledInput label="Display name" name="displayName" disabled={isSubmitting} />
-            <LabelledSelect label="Role" name="role" required disabled={isSubmitting}>
-              {roles.map((role) => <option value={role} key={role}>{role.replaceAll('-', ' ')}</option>)}
-            </LabelledSelect>
-          </SimpleCard>
-          <div className="tw:flex tw:flex-row-reverse tw:gap-2">
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? 'Saving...' : 'Create user'}
-            </Button>
-            <Button variant="secondary" to="/manage-users/1">Cancel</Button>
-          </div>
+      {data?.status !== 'success' && (
+        <Form method="post">
+          <UserFormFields
+            disabled={isSubmitting}
+            usernameError={data?.status === 'error' ? data?.messages.username : undefined}
+            submitText={isSubmitting ? 'Saving...' : 'Create user'}
+          />
         </Form>
       )}
     </Layout>

--- a/app/routes/users/create-user.tsx
+++ b/app/routes/users/create-user.tsx
@@ -67,6 +67,7 @@ export default function CreateUser() {
       {data?.status !== 'success' && (
         <Form method="post">
           <UserFormFields
+            title="Add new user"
             disabled={isSubmitting}
             usernameError={data?.status === 'error' ? data?.messages.username : undefined}
             submitText={isSubmitting ? 'Saving...' : 'Create user'}

--- a/app/routes/users/edit-user.tsx
+++ b/app/routes/users/edit-user.tsx
@@ -1,0 +1,55 @@
+import { type ActionFunctionArgs, type LoaderFunctionArgs, redirect, useFetcher, useLoaderData } from 'react-router';
+import { AuthHelper } from '../../auth/auth-helper.server';
+import { Layout } from '../../common/Layout';
+import { serverContainer } from '../../container/container.server';
+import { UsersService } from '../../users/UsersService.server';
+import { UserFormFields } from './UserFormFields';
+import { ensureAdmin } from './utils';
+
+export async function loader(
+  { request, params }: LoaderFunctionArgs,
+  authHelper: AuthHelper = serverContainer[AuthHelper.name],
+  usersService: UsersService = serverContainer[UsersService.name],
+) {
+  await ensureAdmin(request, authHelper);
+
+  const { userId } = params;
+  const user = await usersService.getUserById(userId!);
+
+  return { user };
+}
+
+export async function action(
+  { request, params }: ActionFunctionArgs,
+  usersService: UsersService = serverContainer[UsersService.name],
+  authHelper: AuthHelper = serverContainer[AuthHelper.name],
+) {
+  await ensureAdmin(request, authHelper);
+
+  const { userId } = params;
+  const formData = await request.formData();
+
+  // TODO Handle error while editing the user
+  await usersService.editUser(userId!, formData);
+  return redirect('/manage-users/1');
+}
+
+export type ActionResult = Awaited<ReturnType<typeof action>>;
+
+export default function EditUser() {
+  const { user } = useLoaderData<typeof loader>();
+  const { Form, state } = useFetcher<ActionResult>();
+  const isSubmitting = state === 'submitting';
+
+  return (
+    <Layout>
+      <Form method="post">
+        <UserFormFields
+          user={user}
+          disabled={isSubmitting}
+          submitText={isSubmitting ? 'Saving...' : 'Update user'}
+        />
+      </Form>
+    </Layout>
+  );
+}

--- a/app/routes/users/manage-users.tsx
+++ b/app/routes/users/manage-users.tsx
@@ -1,4 +1,4 @@
-import { faPlus, faSortAlphaAsc, faSortAlphaDesc, faTrashCan } from '@fortawesome/free-solid-svg-icons';
+import { faPencil, faPlus, faSortAlphaAsc, faSortAlphaDesc, faTrashCan } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { mergeDeepRight } from '@shlinkio/data-manipulation';
 import type { OrderDir } from '@shlinkio/shlink-frontend-kit';
@@ -146,20 +146,31 @@ export default function ManageUsers() {
                   <Table.Cell data-column="Role:"><RoleBadge role={user.role} /></Table.Cell>
                   <Table.Cell
                     className={clsx(
-                      'tw:lg:static tw:lg:text-right tw:lg:[&]:border-b-1', // Big screens
+                      'tw:lg:static tw:lg:[&]:border-b-1', // Big screens
                       'tw:absolute tw:top-0 tw:right-0 tw:[&]:border-b-0', // Small screens
                     )}
                   >
                     {session?.username !== user.username && (
-                      <Button
-                        inline
-                        size="sm"
-                        variant="danger"
-                        aria-label={`Delete user ${user.username}`}
-                        onClick={() => setUserToDelete(user)}
-                      >
-                        <FontAwesomeIcon icon={faTrashCan} />
-                      </Button>
+                      <div className="tw:flex tw:flex-row-reverse tw:gap-x-1">
+                        <Button
+                          inline
+                          size="sm"
+                          variant="danger"
+                          aria-label={`Delete user ${user.username}`}
+                          onClick={() => setUserToDelete(user)}
+                        >
+                          <FontAwesomeIcon icon={faTrashCan} />
+                        </Button>
+                        <Button
+                          inline
+                          size="sm"
+                          variant="secondary"
+                          aria-label={`Edit user ${user.username}`}
+                          to={href('/manage-users/edit/:userId', { userId: user.id.toString() })}
+                        >
+                          <FontAwesomeIcon icon={faPencil} />
+                        </Button>
+                      </div>
                     )}
                   </Table.Cell>
                 </Table.Row>

--- a/app/routes/users/utils.ts
+++ b/app/routes/users/utils.ts
@@ -1,4 +1,5 @@
 import type { AuthHelper } from '../../auth/auth-helper.server';
+import { notFound } from '../../utils/response.server';
 
 /**
  * Verifies current user is an admin, throwing a 404 response otherwise.
@@ -6,6 +7,6 @@ import type { AuthHelper } from '../../auth/auth-helper.server';
 export async function ensureAdmin(request: Request, authHelper: AuthHelper) {
   const { role } = await authHelper.getSession(request, '/login');
   if (role !== 'admin') {
-    throw new Response('Not found', { status: 404 });
+    throw notFound();
   }
 }

--- a/app/servers/ServersRepository.server.ts
+++ b/app/servers/ServersRepository.server.ts
@@ -1,8 +1,8 @@
 import type { EntityManager } from '@mikro-orm/core';
-import { EntityRepository } from '@mikro-orm/core';
+import { BaseEntityRepository } from '../db/BaseEntityRepository';
 import { Server } from '../entities/Server';
 
-export class ServersRepository extends EntityRepository<Server> {
+export class ServersRepository extends BaseEntityRepository<Server> {
   findByPublicIdAndUserId(publicId: string, userId: string): Promise<Server | null> {
     return this.em.findOne(Server, {
       publicId,

--- a/app/servers/ServersService.server.ts
+++ b/app/servers/ServersService.server.ts
@@ -1,4 +1,5 @@
 import type { Server } from '../entities/Server';
+import { NotFoundError } from '../validation/NotFoundError.server';
 import type { ServersRepository } from './ServersRepository.server';
 
 export class ServersService {
@@ -11,7 +12,7 @@ export class ServersService {
   public async getByPublicIdAndUser(publicId: string, userId: string): Promise<Server> {
     const server = await this.#serversRepository.findByPublicIdAndUserId(publicId, userId);
     if (!server) {
-      throw new Error(`Server with public ID ${publicId} not found`);
+      throw new NotFoundError(`Server with public ID ${publicId} not found`);
     }
 
     return server;

--- a/app/users/IncorrectPasswordError.server.ts
+++ b/app/users/IncorrectPasswordError.server.ts
@@ -1,0 +1,6 @@
+export class IncorrectPasswordError extends Error {
+  constructor(username: string) {
+    super(`Incorrect password for user ${username}`);
+    this.name = 'IncorrectPasswordError';
+  }
+}

--- a/app/users/UsersRepository.server.ts
+++ b/app/users/UsersRepository.server.ts
@@ -1,6 +1,6 @@
 import type { EntityManager, FilterQuery, RequiredEntityData } from '@mikro-orm/core';
-import { EntityRepository } from '@mikro-orm/core';
 import type { Order } from '@shlinkio/shlink-frontend-kit';
+import { BaseEntityRepository } from '../db/BaseEntityRepository';
 import { User } from '../entities/User';
 import type { UserOrderableFields } from './UsersService.server';
 
@@ -11,14 +11,9 @@ export type FindAndCountUsersOptions = {
   searchTerm?: string;
 };
 
-export class UsersRepository extends EntityRepository<User> {
-  findOneByUsername(username: string): Promise<User | null> {
-    return this.em.findOne(User, { username });
-  }
-
+export class UsersRepository extends BaseEntityRepository<User> {
   findAndCountUsers({ searchTerm, limit, offset, orderBy }: FindAndCountUsersOptions): Promise<[User[], number]> {
-    return this.em.findAndCount(
-      User,
+    return this.findAndCount(
       this.buildListUsersWhere(searchTerm),
       {
         limit,
@@ -55,14 +50,10 @@ export class UsersRepository extends EntityRepository<User> {
   }
 
   async createUser(userData: Omit<RequiredEntityData<User>, 'createdAt'>): Promise<User> {
-    const user = this.em.create(User, { ...userData, createdAt: new Date() });
+    const user = this.create({ ...userData, createdAt: new Date() });
     await this.em.persist(user).flush();
 
     return user;
-  }
-
-  async deleteUser(userId: string): Promise<void> {
-    await this.em.nativeDelete(User, { id: userId });
   }
 }
 

--- a/app/users/UsersService.server.ts
+++ b/app/users/UsersService.server.ts
@@ -2,7 +2,9 @@ import { UniqueConstraintViolationException } from '@mikro-orm/core';
 import { generatePassword, hashPassword, verifyPassword } from '../auth/passwords.server';
 import type { User } from '../entities/User';
 import { DuplicatedEntryError } from '../validation/DuplicatedEntryError.server';
+import { NotFoundError } from '../validation/NotFoundError.server';
 import { validateFormDataSchema } from '../validation/validator.server';
+import { IncorrectPasswordError } from './IncorrectPasswordError.server';
 import { CREATE_USER_SCHEMA, EDIT_USER_SCHEMA } from './user-schemas.server';
 import type { FindAndCountUsersOptions, UsersRepository } from './UsersRepository.server';
 
@@ -28,12 +30,12 @@ export class UsersService {
   async getUserByCredentials(username: string, password: string): Promise<User> {
     const user = await this.#usersRepository.findOne({ username });
     if (!user) {
-      throw new Error(`User not found with username ${username}`);
+      throw new NotFoundError(`User not found with username ${username}`);
     }
 
     const isPasswordCorrect = await verifyPassword(password, user.password);
     if (!isPasswordCorrect) {
-      throw new Error(`Incorrect password for user ${username}`);
+      throw new IncorrectPasswordError(username);
     }
 
     return user;
@@ -42,7 +44,7 @@ export class UsersService {
   async getUserById(userId: string): Promise<User> {
     const user = await this.#usersRepository.findOne({ id: userId });
     if (!user) {
-      throw new Error(`User not found with id ${userId}`);
+      throw new NotFoundError(`User not found with id ${userId}`);
     }
 
     return user;

--- a/app/users/UsersService.server.ts
+++ b/app/users/UsersService.server.ts
@@ -3,7 +3,7 @@ import { generatePassword, hashPassword, verifyPassword } from '../auth/password
 import type { User } from '../entities/User';
 import { DuplicatedEntryError } from '../validation/DuplicatedEntryError.server';
 import { validateFormDataSchema } from '../validation/validator.server';
-import { USER_CREATION_SCHEMA } from './user-schemas.server';
+import { CREATE_USER_SCHEMA, EDIT_USER_SCHEMA } from './user-schemas.server';
 import type { FindAndCountUsersOptions, UsersRepository } from './UsersRepository.server';
 
 export type UserOrderableFields = keyof Omit<User, 'id' | 'password'>;
@@ -26,7 +26,7 @@ export class UsersService {
   }
 
   async getUserByCredentials(username: string, password: string): Promise<User> {
-    const user = await this.#usersRepository.findOneByUsername(username);
+    const user = await this.#usersRepository.findOne({ username });
     if (!user) {
       throw new Error(`User not found with username ${username}`);
     }
@@ -34,6 +34,15 @@ export class UsersService {
     const isPasswordCorrect = await verifyPassword(password, user.password);
     if (!isPasswordCorrect) {
       throw new Error(`Incorrect password for user ${username}`);
+    }
+
+    return user;
+  }
+
+  async getUserById(userId: string): Promise<User> {
+    const user = await this.#usersRepository.findOne({ id: userId });
+    if (!user) {
+      throw new Error(`User not found with id ${userId}`);
     }
 
     return user;
@@ -58,7 +67,7 @@ export class UsersService {
   }
 
   async createUser(data: FormData): Promise<[User, string]> {
-    const userData = validateFormDataSchema(USER_CREATION_SCHEMA, data);
+    const userData = validateFormDataSchema(CREATE_USER_SCHEMA, data);
     const plainTextTempPassword = generatePassword();
     const password = await hashPassword(plainTextTempPassword);
 
@@ -74,7 +83,23 @@ export class UsersService {
     }
   }
 
+  async editUser(userId: string, data: FormData): Promise<User> {
+    const { displayName, role } = validateFormDataSchema(EDIT_USER_SCHEMA, data);
+    const user = await this.getUserById(userId);
+
+    if (displayName !== undefined) {
+      user.displayName = displayName;
+    }
+    if (role) {
+      user.role = role;
+    }
+
+    await this.#usersRepository.flush();
+
+    return user;
+  }
+
   async deleteUser(userId: string): Promise<void> {
-    await this.#usersRepository.deleteUser(userId);
+    await this.#usersRepository.nativeDelete({ id: userId });
   }
 }

--- a/app/users/user-schemas.server.ts
+++ b/app/users/user-schemas.server.ts
@@ -2,12 +2,12 @@ import { z } from 'zod';
 import { roles } from '../entities/User';
 
 export const EDIT_USER_SCHEMA = z.object({
-  displayName: z.string().trim().optional(),
+  displayName: z.string().max(255).trim().optional(),
   role: z.enum(roles).optional(),
 });
 
 export const CREATE_USER_SCHEMA = z.object({
-  username: z.string().trim().regex(/^(?![._])[a-zA-Z0-9._]+(?<![._])$/),
-  displayName: z.string().trim().optional(),
+  username: z.string().max(255).trim().regex(/^(?![._])[a-zA-Z0-9._]+(?<![._])$/),
+  displayName: z.string().max(255).trim().optional(),
   role: z.enum(roles),
 });

--- a/app/users/user-schemas.server.ts
+++ b/app/users/user-schemas.server.ts
@@ -1,8 +1,13 @@
 import { z } from 'zod';
 import { roles } from '../entities/User';
 
-export const USER_CREATION_SCHEMA = z.object({
-  username: z.string().regex(/^(?![._])[a-zA-Z0-9._]+(?<![._])$/),
-  displayName: z.string().optional(),
+export const EDIT_USER_SCHEMA = z.object({
+  displayName: z.string().trim().optional(),
+  role: z.enum(roles).optional(),
+});
+
+export const CREATE_USER_SCHEMA = z.object({
+  username: z.string().trim().regex(/^(?![._])[a-zA-Z0-9._]+(?<![._])$/),
+  displayName: z.string().trim().optional(),
   role: z.enum(roles),
 });

--- a/app/utils/response.server.ts
+++ b/app/utils/response.server.ts
@@ -2,6 +2,8 @@ import type { ProblemDetailsError } from '@shlinkio/shlink-js-sdk/api-contract';
 
 export const empty = () => new Response(null, { status: 204 });
 
+export const notFound = (body: BodyInit = 'Not found') => new Response(body, { status: 404 });
+
 export const problemDetails = (errorPayload: ProblemDetailsError) => Response.json(
   errorPayload,
   { status: errorPayload.status },

--- a/app/validation/NotFoundError.server.ts
+++ b/app/validation/NotFoundError.server.ts
@@ -1,0 +1,6 @@
+export class NotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'NotFoundError';
+  }
+}

--- a/test/routes/login.test.tsx
+++ b/test/routes/login.test.tsx
@@ -66,7 +66,6 @@ describe('login', () => {
         {
           path: '/',
           Component: Login,
-          HydrateFallback: () => null,
           action: () => ({ error }),
         },
       ]);

--- a/test/routes/users/UserFormFields.test.tsx
+++ b/test/routes/users/UserFormFields.test.tsx
@@ -1,0 +1,46 @@
+import { screen } from '@testing-library/react';
+import { fromPartial } from '@total-typescript/shoehorn';
+import { MemoryRouter } from 'react-router';
+import type { User } from '../../../app/entities/User';
+import type { UserFormFieldsProps } from '../../../app/routes/users/UserFormFields';
+import { UserFormFields } from '../../../app/routes/users/UserFormFields';
+import { checkAccessibility } from '../../__helpers__/accessibility';
+import { renderWithEvents } from '../../__helpers__/set-up-test';
+
+describe('<UserFormFields />', () => {
+  const setUp = (props: Partial<UserFormFieldsProps> = {}) => renderWithEvents(
+    <MemoryRouter>
+      <UserFormFields title="Title" submitText="Submit" {...props} />
+    </MemoryRouter>,
+  );
+
+  it.each([
+    [undefined],
+    [fromPartial<User>({ username: 'foo', role: 'advanced-user' })],
+  ])('passes a11y checks', (user) => checkAccessibility(setUp({ user })));
+
+  it('disables elements when disabled', () => {
+    setUp({ disabled: true });
+
+    expect(screen.getByLabelText(/^Username/)).toBeDisabled();
+    expect(screen.getByLabelText(/^Display name/)).toBeDisabled();
+    expect(screen.getByLabelText(/^Role/)).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it.each([
+    [undefined],
+    [fromPartial<User>({ username: 'foo', role: 'advanced-user' })],
+  ])('sets username as readonly when user is provided', (user) => {
+    setUp({ user });
+    const usernameInput = screen.getByLabelText(/^Username/);
+
+    if (user) {
+      expect(usernameInput).toHaveAttribute('readonly');
+      expect(usernameInput).not.toHaveAttribute('name');
+    } else {
+      expect(usernameInput).not.toHaveAttribute('readonly');
+      expect(usernameInput).toHaveAttribute('name', 'username');
+    }
+  });
+});

--- a/test/routes/users/__snapshots__/RoleBadge.test.tsx.snap
+++ b/test/routes/users/__snapshots__/RoleBadge.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`<RoleBadge /> > renders expected markup 1`] = `
 <div>
   <div
-    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:bg-green-600 tw:text-white"
+    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:whitespace-nowrap tw:bg-green-600 tw:text-white"
   >
     admin
   </div>
@@ -13,7 +13,7 @@ exports[`<RoleBadge /> > renders expected markup 1`] = `
 exports[`<RoleBadge /> > renders expected markup 2`] = `
 <div>
   <div
-    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:bg-gray-500 tw:text-white"
+    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:whitespace-nowrap tw:bg-gray-500 tw:text-white"
   >
     advanced user
   </div>
@@ -23,7 +23,7 @@ exports[`<RoleBadge /> > renders expected markup 2`] = `
 exports[`<RoleBadge /> > renders expected markup 3`] = `
 <div>
   <div
-    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:bg-gray-500 tw:text-white"
+    class="tw:rounded-sm tw:px-1 tw:inline-block tw:font-bold tw:whitespace-nowrap tw:bg-gray-500 tw:text-white"
   >
     managed user
   </div>

--- a/test/routes/users/edit-user.test.tsx
+++ b/test/routes/users/edit-user.test.tsx
@@ -1,0 +1,66 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
+import type { AuthHelper } from '../../../app/auth/auth-helper.server';
+import type { User } from '../../../app/entities/User';
+import { action, loader } from '../../../app/routes/users/edit-user';
+import type { UsersService } from '../../../app/users/UsersService.server';
+import { NotFoundError } from '../../../app/validation/NotFoundError.server';
+
+describe('edit-user', () => {
+  const getSession = vi.fn().mockResolvedValue({ role: 'admin' });
+  const authHelper: AuthHelper = fromPartial({ getSession });
+  const getUserById = vi.fn();
+  const editUser = vi.fn();
+  const usersService: UsersService = fromPartial({ getUserById, editUser });
+  const request: Request = fromPartial({ formData: vi.fn().mockResolvedValue(new FormData()) });
+
+  describe('loader', () => {
+    const runLoader = (params: LoaderFunctionArgs['params']) => loader(
+      fromPartial({ params, request }),
+      authHelper,
+      usersService,
+    );
+
+    it('returns 404 when NotFoundError occurs', async () => {
+      getUserById.mockRejectedValue(new NotFoundError(''));
+      await expect(runLoader({ userId: '123' })).rejects.toThrow(expect.objectContaining({ status: 404 }));
+    });
+
+    it('throws unknown errors verbatim', async () => {
+      const unknownError = new Error('Something went wrong');
+      getUserById.mockRejectedValue(unknownError);
+
+      await expect(runLoader({ userId: '123' })).rejects.toThrow(unknownError);
+    });
+
+    it.each([{ userId: '123' }, { userId: 'abc' }])('returns user by id', async ({ userId }) => {
+      const user: User = fromPartial({ id: 'abc123' });
+      getUserById.mockResolvedValue(user);
+
+      const result = await runLoader({ userId });
+
+      expect(result).toEqual({ user });
+      expect(getUserById).toHaveBeenCalledWith(userId);
+    });
+  });
+
+  describe('action', () => {
+    const runAction = (params: ActionFunctionArgs['params']) => action(
+      fromPartial({ params, request }),
+      authHelper,
+      usersService,
+    );
+
+    it.only.each([{ userId: '123' }, { userId: 'abc' }])('edits user and redirects to list', async ({ userId }) => {
+      editUser.mockResolvedValue(fromPartial({ id: 'abc123' }));
+
+      const response = await runAction({ userId });
+
+      expect(response.status).toEqual(302);
+      expect(response.headers.get('Location')).toEqual('/manage-users/1');
+      expect(editUser).toHaveBeenCalledWith(userId, new FormData());
+    });
+  });
+
+  describe.skip('<EditUser />', () => {});
+});

--- a/test/routes/users/edit-user.test.tsx
+++ b/test/routes/users/edit-user.test.tsx
@@ -1,10 +1,14 @@
+import { screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
+import { createRoutesStub } from 'react-router';
 import type { AuthHelper } from '../../../app/auth/auth-helper.server';
 import type { User } from '../../../app/entities/User';
-import { action, loader } from '../../../app/routes/users/edit-user';
+import EditUser, { action, loader } from '../../../app/routes/users/edit-user';
 import type { UsersService } from '../../../app/users/UsersService.server';
 import { NotFoundError } from '../../../app/validation/NotFoundError.server';
+import { checkAccessibility } from '../../__helpers__/accessibility';
+import { renderWithEvents } from '../../__helpers__/set-up-test';
 
 describe('edit-user', () => {
   const getSession = vi.fn().mockResolvedValue({ role: 'admin' });
@@ -51,7 +55,7 @@ describe('edit-user', () => {
       usersService,
     );
 
-    it.only.each([{ userId: '123' }, { userId: 'abc' }])('edits user and redirects to list', async ({ userId }) => {
+    it.each([{ userId: '123' }, { userId: 'abc' }])('edits user and redirects to list', async ({ userId }) => {
       editUser.mockResolvedValue(fromPartial({ id: 'abc123' }));
 
       const response = await runAction({ userId });
@@ -62,5 +66,40 @@ describe('edit-user', () => {
     });
   });
 
-  describe.skip('<EditUser />', () => {});
+  describe('<EditUser />', () => {
+    const setUp = async (user: User) => {
+      const path = '';
+      const Stub = createRoutesStub([
+        {
+          path,
+          Component: EditUser,
+          loader: () => ({ user }),
+          action: () => ({}),
+        },
+      ]);
+
+      const result = renderWithEvents(<Stub initialEntries={[path]} />);
+      await screen.findByText('Edit user');
+
+      return result;
+    };
+
+    it('passes a11y checks', () => checkAccessibility(setUp(
+      fromPartial<User>({ id: 'def', username: 'bar', displayName: 'Jane Doe', role: 'admin' }),
+    )));
+
+    it.each([
+      [fromPartial<User>({ id: 'abc', username: 'foo', displayName: 'Foo Bar', role: 'advanced-user' })],
+      [fromPartial<User>({ id: 'def', username: 'bar', displayName: 'Jane Doe', role: 'admin' })],
+    ])('loads the form with the user data set on it', async (user) => {
+      await setUp(user);
+
+      const usernameInput = screen.getByLabelText(/^Username/);
+      expect(usernameInput).toHaveValue(user.username);
+      expect(usernameInput).toHaveAttribute('readonly');
+
+      expect(screen.getByLabelText('Display name')).toHaveValue(user.displayName);
+      expect(screen.getByLabelText(/^Role/)).toHaveValue(user.role);
+    });
+  });
 });

--- a/test/routes/users/manage-users.test.tsx
+++ b/test/routes/users/manage-users.test.tsx
@@ -91,7 +91,10 @@ describe('manage-users', () => {
         {
           path: '/manage-users/create',
           Component: () => <>Create user</>,
-          HydrateFallback: () => null,
+        },
+        {
+          path: '/manage-users/edit/123',
+          Component: () => <>Edit user</>,
         },
       ]);
       const renderResult = renderWithEvents(<Stub initialEntries={['/manage-users/1']} />);
@@ -217,22 +220,26 @@ describe('manage-users', () => {
       await waitFor(() => expect(screen.getByText('Create user')).toBeInTheDocument());
     });
 
-    it('shows delete button only for users other than current one', async () => {
-      await setUp({
-        currentUsername: 'current',
-        users: [
-          mockUser({ username: 'foo', displayName: 'John Doe', role: 'admin' }),
-          mockUser({ username: 'bar', displayName: 'John Doe', role: 'advanced-user' }),
-          mockUser({ username: 'current', displayName: 'John Doe', role: 'admin' }),
-          mockUser({ username: 'baz', displayName: 'John Doe', role: 'managed-user' }),
-        ],
-      });
+    it('shows interaction buttons only for users other than current one', async () => {
+      const users = [
+        mockUser({ username: 'foo', displayName: 'John Doe', role: 'admin' }),
+        mockUser({ username: 'bar', displayName: 'John Doe', role: 'advanced-user' }),
+        mockUser({ username: 'current', displayName: 'John Doe', role: 'admin' }),
+        mockUser({ username: 'baz', displayName: 'John Doe', role: 'managed-user' }),
+      ];
+      await setUp({ currentUsername: 'current', users });
 
       expect(screen.getAllByLabelText(/^Delete user/)).toHaveLength(3);
       expect(screen.getByLabelText('Delete user foo')).toBeInTheDocument();
       expect(screen.getByLabelText('Delete user bar')).toBeInTheDocument();
       expect(screen.getByLabelText('Delete user baz')).toBeInTheDocument();
       expect(screen.queryByLabelText('Delete user current')).not.toBeInTheDocument();
+
+      expect(screen.getAllByLabelText(/^Edit user/)).toHaveLength(3);
+      expect(screen.getByLabelText('Edit user foo')).toBeInTheDocument();
+      expect(screen.getByLabelText('Edit user bar')).toBeInTheDocument();
+      expect(screen.getByLabelText('Edit user baz')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Edit user current')).not.toBeInTheDocument();
     });
 
     it('shows information about the user to be deleted', async () => {

--- a/test/servers/ServersService.server.test.ts
+++ b/test/servers/ServersService.server.test.ts
@@ -2,6 +2,7 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import type { Server } from '../../app/entities/Server';
 import type { ServersRepository } from '../../app/servers/ServersRepository.server';
 import { ServersService } from '../../app/servers/ServersService.server';
+import { NotFoundError } from '../../app/validation/NotFoundError.server';
 
 describe('ServersService', () => {
   const findByPublicIdAndUserId = vi.fn();
@@ -17,7 +18,7 @@ describe('ServersService', () => {
   describe('getByPublicIdAndUser', () => {
     it('throws error if server is not found', async () => {
       await expect(() => service.getByPublicIdAndUser('123', '1')).rejects.toEqual(
-        new Error('Server with public ID 123 not found'),
+        new NotFoundError('Server with public ID 123 not found'),
       );
     });
 

--- a/test/users/UsersService.server.test.ts
+++ b/test/users/UsersService.server.test.ts
@@ -7,28 +7,28 @@ import { UsersService } from '../../app/users/UsersService.server';
 import { DuplicatedEntryError } from '../../app/validation/DuplicatedEntryError.server';
 
 describe('UsersService', () => {
-  const findOneByUsername = vi.fn();
+  const findOne = vi.fn();
   const findAndCountUsers = vi.fn();
   const createUser = vi.fn();
-  const deleteUser = vi.fn();
+  const nativeDelete = vi.fn();
   let usersRepo: UsersRepository;
   let usersService: UsersService;
 
   beforeEach(() => {
-    usersRepo = fromPartial<UsersRepository>({ findOneByUsername, findAndCountUsers, createUser, deleteUser });
+    usersRepo = fromPartial<UsersRepository>({ findOne, findAndCountUsers, createUser, nativeDelete });
     usersService = new UsersService(usersRepo);
   });
 
   describe('getUserByCredentials', () => {
     it('throws when user is not found', async () => {
-      findOneByUsername.mockResolvedValue(null);
+      findOne.mockResolvedValue(null);
       await expect(() => usersService.getUserByCredentials('foo', 'bar')).rejects.toEqual(
         new Error('User not found with username foo'),
       );
     });
 
     it('throws if password does not match', async () => {
-      findOneByUsername.mockResolvedValue(fromPartial<User>({ password: await hashPassword('the right one') }));
+      findOne.mockResolvedValue(fromPartial<User>({ password: await hashPassword('the right one') }));
       await expect(() => usersService.getUserByCredentials('foo', 'bar')).rejects.toEqual(
         new Error('Incorrect password for user foo'),
       );
@@ -36,7 +36,7 @@ describe('UsersService', () => {
 
     it('returns user if password is correct', async () => {
       const expectedUser = fromPartial<User>({ password: await hashPassword('bar') });
-      findOneByUsername.mockResolvedValue(expectedUser);
+      findOne.mockResolvedValue(expectedUser);
 
       const result = await usersService.getUserByCredentials('foo', 'bar');
 
@@ -176,7 +176,7 @@ describe('UsersService', () => {
   describe('deleteUser', () => {
     it('deletes user via repository', async () => {
       await usersService.deleteUser('123');
-      expect(deleteUser).toHaveBeenCalledWith('123');
+      expect(nativeDelete).toHaveBeenCalledWith({ id: '123' });
     });
   });
 });

--- a/test/users/UsersService.server.test.ts
+++ b/test/users/UsersService.server.test.ts
@@ -210,7 +210,7 @@ describe('UsersService', () => {
   });
 
   describe('editUser', () => {
-    it.only.each([
+    it.each([
       {
         providedData: createFormData({}),
         expectedResult: { displayName: 'initial_display_name', role: 'admin' },

--- a/test/users/UsersService.server.test.ts
+++ b/test/users/UsersService.server.test.ts
@@ -2,9 +2,11 @@ import { UniqueConstraintViolationException } from '@mikro-orm/core';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { hashPassword, verifyPassword } from '../../app/auth/passwords.server';
 import type { User } from '../../app/entities/User';
+import { IncorrectPasswordError } from '../../app/users/IncorrectPasswordError.server';
 import type { UsersRepository } from '../../app/users/UsersRepository.server';
 import { UsersService } from '../../app/users/UsersService.server';
 import { DuplicatedEntryError } from '../../app/validation/DuplicatedEntryError.server';
+import { NotFoundError } from '../../app/validation/NotFoundError.server';
 
 describe('UsersService', () => {
   const findOne = vi.fn();
@@ -36,7 +38,7 @@ describe('UsersService', () => {
       findOne.mockResolvedValue(null);
 
       await expect(usersService.getUserByCredentials('foo', 'bar')).rejects.toEqual(
-        new Error('User not found with username foo'),
+        new NotFoundError('User not found with username foo'),
       );
       expect(findOne).toHaveBeenCalledWith({ username: 'foo' });
     });
@@ -45,7 +47,7 @@ describe('UsersService', () => {
       findOne.mockResolvedValue(fromPartial<User>({ password: await hashPassword('the right one') }));
 
       await expect(usersService.getUserByCredentials('foo', 'bar')).rejects.toEqual(
-        new Error('Incorrect password for user foo'),
+        new IncorrectPasswordError('foo'),
       );
       expect(findOne).toHaveBeenCalledWith({ username: 'foo' });
     });
@@ -66,7 +68,7 @@ describe('UsersService', () => {
       findOne.mockResolvedValue(null);
 
       await expect(usersService.getUserById('abc123')).rejects.toEqual(
-        new Error('User not found with id abc123'),
+        new NotFoundError('User not found with id abc123'),
       );
       expect(findOne).toHaveBeenCalledWith({ id: 'abc123' });
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,6 +17,13 @@ export default defineConfig({
     target: 'esnext',
   },
 
+  server: {
+    watch: {
+      // Do not watch test files or generated files, avoiding the dev server to constantly reload when not needed
+      ignored: ['**/.idea/**', '**/.git/**', '**/build/**', '**/coverage/**', '**/data/**', '**/test/**'],
+    },
+  },
+
   test: {
     globals: true,
     allowOnly: true,


### PR DESCRIPTION
Closes #6 

Allow existing users to be edited. For now only display name and role can be changed.

https://github.com/user-attachments/assets/615ab8d3-0154-4138-af57-620c5b646eec

Passwords will be treated separately, allowing admins to reset the password of any user and users to recover their own password.