### PR TITLE
Normalize all paths with an entity ID

### DIFF
--- a/app/routes.ts
+++ b/app/routes.ts
@@ -18,9 +18,11 @@ export default [
   layout('routes/users/manage-users.tsx', prefix('/manage-users', [
     route('create', './routes/users/create-user.tsx'),
     route('delete', './routes/users/delete-user.ts'),
-    route('edit/:userPublicId', './routes/users/edit-user.tsx'),
-    route('edit/:userPublicId/servers', './routes/users/edit-user-servers.tsx'),
-    route('reset-password/:userPublicId', './routes/users/reset-user-password.tsx'),
+    ...prefix(':userPublicId', [
+      route('edit', './routes/users/edit-user.tsx'),
+      route('edit-servers', './routes/users/edit-user-servers.tsx'),
+      route('reset-password', './routes/users/reset-user-password.tsx'),
+    ]),
     route(':page', './routes/users/list-users.tsx'),
   ])),
 
@@ -28,7 +30,7 @@ export default [
   layout('./routes/servers/manage-servers.tsx', prefix('/manage-servers', [
     route('create', './routes/servers/create-server.tsx'),
     route('delete', './routes/servers/delete-server.ts'),
-    route('edit/:serverPublicId', './routes/servers/edit-server.tsx'),
+    route(':serverPublicId/edit', './routes/servers/edit-server.tsx'),
     route(':page', './routes/servers/list-servers.tsx'),
   ])),
 ] satisfies RouteConfig;

--- a/app/routes/servers/list-servers.tsx
+++ b/app/routes/servers/list-servers.tsx
@@ -105,7 +105,7 @@ export default function ListServers() {
                     size="sm"
                     variant="secondary"
                     aria-label={`Edit server ${server.name}`}
-                    to={href('/manage-servers/edit/:serverPublicId', { serverPublicId: server.publicId })}
+                    to={href('/manage-servers/:serverPublicId/edit', { serverPublicId: server.publicId })}
                   >
                     <FontAwesomeIcon icon={faPencil} />
                   </Button>

--- a/app/routes/users/list-users.tsx
+++ b/app/routes/users/list-users.tsx
@@ -175,18 +175,18 @@ export default function ListUsers() {
                           <UserButton
                             label={`Servers for ${user.username}`}
                             icon={faServer}
-                            to={href('/manage-users/edit/:userPublicId/servers', { userPublicId: user.publicId })}
+                            to={href('/manage-users/:userPublicId/edit-servers', { userPublicId: user.publicId })}
                           />
                         )}
                         <UserButton
                           label={`Reset ${user.username} password`}
                           icon={faKey}
-                          to={href('/manage-users/reset-password/:userPublicId', { userPublicId: user.publicId })}
+                          to={href('/manage-users/:userPublicId/reset-password', { userPublicId: user.publicId })}
                         />
                         <UserButton
                           label={`Edit ${user.username}`}
                           icon={faPencil}
-                          to={href('/manage-users/edit/:userPublicId', { userPublicId: user.publicId })}
+                          to={href('/manage-users/:userPublicId/edit', { userPublicId: user.publicId })}
                         />
                         <UserButton
                           danger

--- a/test/routes/users/edit-user-servers.test.tsx
+++ b/test/routes/users/edit-user-servers.test.tsx
@@ -63,7 +63,7 @@ describe('edit-user-servers', () => {
   describe('<EditUserServers />', () => {
     const setUp = async () => {
       const prevPath = '/manage-users/1';
-      const path = '/manage-users/edit/1/servers';
+      const path = '/manage-users/1/edit-servers';
       const Stub = createRoutesStub([
         {
           path: prevPath,

--- a/test/routes/users/list-users.test.tsx
+++ b/test/routes/users/list-users.test.tsx
@@ -80,7 +80,7 @@ describe('list-users', () => {
           Component: () => <>Create user</>,
         },
         {
-          path: '/manage-users/edit/123',
+          path: '/manage-users/123/edit',
           Component: () => <>Edit user</>,
         },
       ]);

--- a/test/routes/users/reset-user-password.test.tsx
+++ b/test/routes/users/reset-user-password.test.tsx
@@ -41,7 +41,7 @@ describe('reset-user-password', () => {
 
   describe('<ResetUserPassword />', () => {
     const setUp = async () => {
-      const path = '/manage-users/reset-password/123';
+      const path = '/manage-users/123/reset-password';
       const user = fromPartial<User>({ username: 'john_doe' });
       const Stub = createRoutesStub([
         {


### PR DESCRIPTION
All routes with an entitiy ID on them now have the action after the ID, not before.