### PR TITLE
Add tini to docker image using the right architecture

### DIFF
--- a/.github/workflows/ci-docker-image-build.yml
+++ b/.github/workflows/ci-docker-image-build.yml
@@ -8,3 +8,5 @@ on:
 jobs:
   build-docker-image:
     uses: shlinkio/github-actions/.github/workflows/docker-image-build-ci.yml@main
+    with:
+      platforms: 'linux/arm64/v8,linux/amd64'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
-## [Unreleased]
+## [0.1.2] - 2025-09-16
 ### Added
 - *Nothing*
 
@@ -18,7 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - *Nothing*
 
 ### Fixed
-- *Nothing*
+- [#726](https://github.com/shlinkio/shlink-dashboard/issues/726) Fix tini downloaded with the wrong architecture in the ARM docker image.
 
 
 ## [0.1.1] - 2025-08-08

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,10 @@ ARG VERSION="latest"
 ENV VERSION=${VERSION}
 LABEL maintainer="Alejandro Celaya <alejandro@alejandrocelaya.com>"
 ENV NODE_ENV="production"
+
+# This is set by Docker BuildKit based on the value passed to `--platform`
+ARG TARGETARCH
+ENV TINI_NAME="tini-${TARGETARCH}"
 ENV TINI_VERSION="v0.19.0"
 
 USER root
@@ -28,7 +32,7 @@ RUN npm ci --omit dev && npm cache clean --force
 RUN mkdir data && chown $UID:0 data
 
 # Install tini
-ADD --chmod=755 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+ADD --chmod=755 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/${TINI_NAME} /sbin/tini
 
 # Expose default port
 EXPOSE 3005


### PR DESCRIPTION
Closes #726 

Update dockerfile to detect the platform it is being build for (using `TARGETARCH` arg, which is set by docker BuildKit), and then dynamically build the name of the tini binary to be downloaded.