### PR TITLE
Vertically center home and login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 * [shlink-web-component#784](https://github.com/shlinkio/shlink-web-component/issues/784) Add optional `long-url` query parameter to short URL creation to prefill the long URL programmatically.
 
 ### Changed
-* *Nothing*
+* [#675](https://github.com/shlinkio/shlink-dashboard/issues/675) Vertically center home and login page content.
 
 ### Deprecated
 * *Nothing*

--- a/app/common/CenteredContentLayout.tsx
+++ b/app/common/CenteredContentLayout.tsx
@@ -1,0 +1,17 @@
+import type { FC, PropsWithChildren } from 'react';
+import { Layout } from './Layout';
+
+/**
+ * A Layout used to render single-node children which will cause them to be centered on the viewport while space is
+ * available.
+ * Once children do not fit, vertical scroll will appear normally.
+ */
+export const CenteredContentLayout: FC<PropsWithChildren> = ({ children }) => (
+  <div className="flex items-center min-h-full">
+    <Layout>
+      <div className="mx-auto xl:w-3/5 lg:w-3/4">
+        {children}
+      </div>
+    </Layout>
+  </div>
+);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -58,7 +58,7 @@ export default function App({ loaderData }: RouteComponentProps<Route.ComponentP
       <body>
         <SessionProvider value={sessionData ?? null}>
           <MainHeader />
-          <div className="pt-(--header-height)">
+          <div className="h-full pt-(--header-height)">
             <Outlet />
           </div>
           <Scripts />

--- a/app/routes/index/home.tsx
+++ b/app/routes/index/home.tsx
@@ -1,6 +1,6 @@
 import type { LoaderFunctionArgs } from 'react-router';
 import { AuthHelper } from '../../auth/auth-helper.server';
-import { Layout } from '../../common/Layout';
+import { CenteredContentLayout } from '../../common/CenteredContentLayout';
 import { serverContainer } from '../../container/container.server';
 import { ServersService } from '../../servers/ServersService.server';
 import type { RouteComponentProps } from '../types';
@@ -22,12 +22,8 @@ export default function Home({ loaderData }: RouteComponentProps<Route.Component
   const { servers } = loaderData;
 
   return (
-    <Layout>
-      <div className="md:flex md:items-center md:h-full md:pb-0 pb-3">
-        <div className="mx-auto xl:w-1/2 lg:w-3/4 w-full">
-          <WelcomeCard servers={servers} />
-        </div>
-      </div>
-    </Layout>
+    <CenteredContentLayout>
+      <WelcomeCard servers={servers} />
+    </CenteredContentLayout>
   );
 }

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -2,6 +2,7 @@ import { Button, LabelledInput, SimpleCard } from '@shlinkio/shlink-frontend-kit
 import type { ActionFunctionArgs, LoaderFunctionArgs } from 'react-router';
 import { redirect,useFetcher  } from 'react-router';
 import { AuthHelper } from '../auth/auth-helper.server';
+import { CenteredContentLayout } from '../common/CenteredContentLayout';
 import { serverContainer } from '../container/container.server';
 
 const INCORRECT_CREDENTIAL_ERROR_PREFIXES = ['Incorrect password', 'User not found'];
@@ -36,7 +37,7 @@ export default function Login() {
   const isSaving = fetcher.state === 'submitting';
 
   return (
-    <div className="mt-8 mx-8 lg:mx-auto lg:w-[50%]">
+    <CenteredContentLayout>
       <SimpleCard>
         <fetcher.Form method="post" className="flex flex-col gap-4">
           <LabelledInput label="Username:" name="username" hiddenRequired />
@@ -49,6 +50,6 @@ export default function Login() {
           )}
         </fetcher.Form>
       </SimpleCard>
-    </div>
+    </CenteredContentLayout>
   );
 }

--- a/app/tailwind.css
+++ b/app/tailwind.css
@@ -6,6 +6,7 @@
 
 @layer base {
     :root {
-        --header-height: 52px;
+        --footer-height: 2.3rem;
+        --footer-margin: .8rem;
     }
 }


### PR DESCRIPTION
Closes #675 

Home and login pages display a single card each, but this was not vertically centered to be consistent with how it is displayed in Shlink Web Client.

This PR adds the necessary changes for the centering.

Login page before:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/ba59f603-512a-4809-aa78-bede7aac50b5" />

Login page after:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/df1337d6-36a8-462f-98fc-b6517a9f8a14" />

Home page before:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/8e3f7542-d629-4eee-82b9-b456f4c3485d" />

Home page after:
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/3eae417d-fe1c-4a4a-8f27-fc609815803c" />
