### PR TITLE
Prevent a crash when loading the domains page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.2.1] - 2026-01-16
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#838](https://github.com/shlinkio/shlink-dashboard/issues/838) Fix domains page erroring out if any of the domains is not reachable when checking its status.
+
+
 ## [0.2.0] - 2025-12-12
 ### Added
 * [shlink-web-component#839](https://github.com/shlinkio/shlink-web-component/issues/839) Allow filtering short URLs by excluded tags when using Shlink >=4.6.0

--- a/app/api/apiClientBuilder.server.ts
+++ b/app/api/apiClientBuilder.server.ts
@@ -1,5 +1,5 @@
 import { ShlinkApiClient } from '@shlinkio/shlink-js-sdk';
-import { NodeHttpClient } from '@shlinkio/shlink-js-sdk/node';
+import { FetchHttpClient } from '@shlinkio/shlink-js-sdk/fetch';
 import type { Server } from '../entities/Server';
 
 const apiClients = new Map<string, ShlinkApiClient>();
@@ -12,7 +12,7 @@ export const apiClientBuilder = (server: Server) => {
     return existingApiClient;
   }
 
-  const apiClient = new ShlinkApiClient(new NodeHttpClient(), server);
+  const apiClient = new ShlinkApiClient(new FetchHttpClient(), server);
   apiClients.set(key, apiClient);
   return apiClient;
 };


### PR DESCRIPTION
Closes #838 

Prevent a crash when loading the domains page if any of the domains is not publicly reachable by the dashboard's backend.

In order to fix this, we are changing from Shlink's SDK `NodeHttpClient` to `FetchHttpClient`, which doesn't cause the whole process to crash.

`NodeHttpClient` is slightly more performant, but if we ever wanted to support using deno or bun, we would have to change anyway.