### PR TITLE
Add missing unique user-server constraint in user_has_servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [0.2.2] - 2026-01-17
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* [#841](https://github.com/shlinkio/shlink-dashboard/issues/841) Fix 500 error when creting new servers.
+
+
 ## [0.2.1] - 2026-01-16
 ### Added
 * *Nothing*

--- a/app/db/migrations/Migration20260117070847.ts
+++ b/app/db/migrations/Migration20260117070847.ts
@@ -1,0 +1,17 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260117070847 extends Migration {
+  override async up(): Promise<void> {
+    const knex = this.getKnex();
+    await knex.schema.table('user_has_servers', (builder) => {
+      builder.unique(['user_id', 'server_id'], { indexName: 'IDX_user_server' });
+    });
+  }
+
+  override async down(): Promise<void> {
+    const knex = this.getKnex();
+    await knex.schema.table('user_has_servers', (builder) => {
+      builder.dropUnique(['user_id', 'server_id'], 'IDX_user_server');
+    });
+  }
+}

--- a/app/servers/ServersRepository.server.ts
+++ b/app/servers/ServersRepository.server.ts
@@ -42,7 +42,7 @@ export class ServersRepository extends BaseEntityRepository<Server> {
     const server = this.create({ publicId: crypto.randomUUID(), ...serverData });
     server.users.add(user);
 
-    await this.em.persistAndFlush(server);
+    await this.em.persist(server).flush();
 
     return server;
   }

--- a/app/users/UsersRepository.server.ts
+++ b/app/users/UsersRepository.server.ts
@@ -38,7 +38,7 @@ export class UsersRepository extends BaseEntityRepository<User> {
       createdAt: new Date(),
       publicId: crypto.randomUUID(),
     });
-    await this.em.persistAndFlush(user);
+    await this.em.persist(user).flush();
 
     return user;
   }


### PR DESCRIPTION
Closes #841 

Add missing unique constraint to `user_has_servers` table between `user_id` and `server_id`, which fixes an error when trying to create new servers.