### PR TITLE
Fix regressions introduced with react-router 8

### DIFF
--- a/app/auth/auth-helper.server.ts
+++ b/app/auth/auth-helper.server.ts
@@ -1,7 +1,6 @@
 import type { Session, SessionStorage } from 'react-router';
 import { redirect } from 'react-router';
 import type { Authenticator } from 'remix-auth';
-import { requestQueryParam } from '../utils/request.server';
 import { CREDENTIALS_STRATEGY } from './auth.server';
 import type { SessionData, ShlinkSessionData } from './session-context';
 
@@ -18,14 +17,14 @@ export class AuthHelper {
     this.#sessionStorage = sessionStorage;
   }
 
-  async login(request: Request): Promise<Response> {
+  async login(request: Request, url: URL): Promise<Response> {
     const [sessionData, session] = await Promise.all([
       this.#authenticator.authenticate(CREDENTIALS_STRATEGY, request),
       this.sessionFromRequest(request),
     ]);
     session.set('sessionData', sessionData);
 
-    const redirectTo = requestQueryParam(request, 'redirect-to');
+    const redirectTo = url.searchParams.get('redirect-to');
     const successRedirect = redirectTo && !redirectTo.toLowerCase().startsWith('http') ? redirectTo : '/';
 
     return redirect(successRedirect, {
@@ -40,16 +39,16 @@ export class AuthHelper {
     });
   }
 
-  async getSession(request: Request): Promise<SessionData | undefined>;
-  async getSession(request: Request, onMissingSessionRedirectTo: string): Promise<SessionData>;
-  async getSession(request: Request, onMissingSessionRedirectTo?: string): Promise<SessionData | undefined> {
+  async getSession(request: Request, url: URL): Promise<SessionData | undefined>;
+  async getSession(request: Request, url: URL, onMissingSessionRedirectTo: string): Promise<SessionData>;
+  async getSession(request: Request, url: URL, onMissingSessionRedirectTo?: string): Promise<SessionData | undefined> {
     const [sessionData] = await this.sessionAndData(request);
     if (onMissingSessionRedirectTo && !sessionData) {
       throw redirect(onMissingSessionRedirectTo);
     }
 
     // Redirect logged-in users with a temp password to the change-password form, unless that's already the active route
-    if (sessionData?.tempPassword && new URL(request.url).pathname !== '/change-password') {
+    if (sessionData?.tempPassword && url.pathname !== '/change-password') {
       throw redirect('/change-password');
     }
 
@@ -87,8 +86,8 @@ export class AuthHelper {
     return [session.get('sessionData'), session];
   }
 
-  async isAuthenticated(request: Request): Promise<boolean> {
-    const sessionData = await this.getSession(request);
+  async isAuthenticated(request: Request, url: URL): Promise<boolean> {
+    const sessionData = await this.getSession(request, url);
     return !!sessionData;
   }
 }

--- a/app/middleware/middleware.server.ts
+++ b/app/middleware/middleware.server.ts
@@ -16,11 +16,11 @@ export const sessionContext = createContext<SessionData>();
  * @todo Redirect to login with a redirect-to param to return to original location
  */
 export const authMiddleware = async function (
-  { request, context },
+  { request, url, context },
   next,
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
-  const sessionData = await authHelper.getSession(request, '/login');
+  const sessionData = await authHelper.getSession(request, url, '/login');
   context.set(sessionContext, sessionData);
 
   return next();

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,16 +16,16 @@ import './tailwind.css';
 export const middleware = [forkEmMiddleware];
 
 export async function loader(
-  { request }: LoaderFunctionArgs,
+  { request, url }: LoaderFunctionArgs,
   settingsService: SettingsService = serverContainer[SettingsService.name],
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
-  const { pathname } = new URL(request.url);
+  const { pathname } = url;
   const isPublicRoute = ['/login', '/logout'].includes(pathname);
   const sessionData = await (isPublicRoute
-    ? authHelper.getSession(request)
+    ? authHelper.getSession(request, url)
     : // For non-public routes, redirect to login route
-      authHelper.getSession(request, `/login?${new URLSearchParams({ 'redirect-to': pathname })}`));
+      authHelper.getSession(request, url, `/login?${new URLSearchParams({ 'redirect-to': pathname })}`));
 
   const settings = sessionData && (await settingsService.userSettings(sessionData.publicId));
   const sessionCookie = await authHelper.refreshSessionExpiration(request);

--- a/app/routes/index/home.tsx
+++ b/app/routes/index/home.tsx
@@ -8,11 +8,11 @@ import type { Route } from './+types/home';
 import { WelcomeCard } from './WelcomeCard';
 
 export async function loader(
-  { request }: LoaderFunctionArgs,
+  { request, url }: LoaderFunctionArgs,
   serversService: ServersService = serverContainer[ServersService.name],
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
-  const sessionData = await authHelper.getSession(request, '/login');
+  const sessionData = await authHelper.getSession(request, url, '/login');
   const servers = await serversService.getUserServers(sessionData.publicId);
 
   return { servers };

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -8,20 +8,20 @@ import { serverContainer } from '../container/container.server';
 const INCORRECT_CREDENTIAL_ERROR_PREFIXES = ['Incorrect password', 'User not found'];
 
 export async function loader(
-  { request }: LoaderFunctionArgs,
+  { request, url }: LoaderFunctionArgs,
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
   // If the user is already authenticated, redirect to home
-  const isAuthenticated = await authHelper.isAuthenticated(request);
+  const isAuthenticated = await authHelper.isAuthenticated(request, url);
   return isAuthenticated ? redirect('/') : {};
 }
 
 export async function action(
-  { request }: ActionFunctionArgs,
+  { request, url }: ActionFunctionArgs,
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
   try {
-    return await authHelper.login(request);
+    return await authHelper.login(request, url);
   } catch (e: any) {
     // TODO Use a more robust way to detect errors
     if (INCORRECT_CREDENTIAL_ERROR_PREFIXES.some((prefix) => e.message.startsWith(prefix))) {

--- a/app/routes/profile/profile.tsx
+++ b/app/routes/profile/profile.tsx
@@ -8,7 +8,6 @@ import { serverContainer } from '../../container/container.server';
 import { authMiddleware, sessionContext } from '../../middleware/middleware.server';
 import { CHANGE_PASSWORD_ACTION, PROFILE_ACTION } from '../../users/user-profile-actions';
 import { UsersService } from '../../users/UsersService.server';
-import { requestQueryParam } from '../../utils/request.server';
 import { changePasswordAction } from './change-password-action.server';
 import { ChangePasswordForm } from './ChangePasswordForm';
 import { editProfileAction } from './edit-profile-action.server';
@@ -17,12 +16,12 @@ import { EditProfileForm } from './EditProfileForm';
 export const middleware = [authMiddleware];
 
 export async function action(
-  { request, context }: ActionFunctionArgs,
+  { request, context, url }: ActionFunctionArgs,
   usersService: UsersService = serverContainer[UsersService.name],
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
   const sessionData = context.get(sessionContext);
-  const action = requestQueryParam(request, 'action');
+  const action = url.searchParams.get('action');
   const formData = await request.formData();
 
   switch (action) {

--- a/app/routes/save-tags-colors.ts
+++ b/app/routes/save-tags-colors.ts
@@ -5,11 +5,11 @@ import { TagsService } from '../tags/TagsService.server';
 import { empty } from '../utils/response.server';
 
 export async function action(
-  { params, request }: ActionFunctionArgs,
+  { params, request, url }: ActionFunctionArgs,
   tagsService: TagsService = serverContainer[TagsService.name],
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ) {
-  const sessionData = await authHelper.getSession(request);
+  const sessionData = await authHelper.getSession(request, url);
   if (!sessionData) {
     return empty();
   }

--- a/app/routes/servers/list-servers.tsx
+++ b/app/routes/servers/list-servers.tsx
@@ -10,16 +10,15 @@ import { serverContainer } from '../../container/container.server';
 import type { PlainServer } from '../../entities/Server';
 import { sessionContext } from '../../middleware/middleware.server';
 import { ServersService } from '../../servers/ServersService.server';
-import { requestQueryParams } from '../../utils/request.server';
 import type { RouteComponentProps } from '../types';
 import type { Route } from './+types/list-servers';
 import { DeleteServerModal } from './DeleteServerModal';
 
 export async function loader(
-  { request, context, params }: LoaderFunctionArgs,
+  { context, params, url }: LoaderFunctionArgs,
   serversService: ServersService = serverContainer[ServersService.name],
 ) {
-  const query = requestQueryParams(request);
+  const query = url.searchParams;
   const currentSearchTerm = query.get('search-term') ?? undefined;
   const page = Number(params.page ?? 1);
   const itemsPerPage = query.has('items-per-page') ? Number(query.get('items-per-page')) : undefined;

--- a/app/routes/settings.tsx
+++ b/app/routes/settings.tsx
@@ -12,20 +12,20 @@ import type { Route } from './+types/settings';
 import type { RouteComponentProps } from './types';
 
 export async function loader(
-  { request }: LoaderFunctionArgs,
+  { request, url }: LoaderFunctionArgs,
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
   settingsService: SettingsService = serverContainer[SettingsService.name],
 ) {
-  const { publicId } = await authHelper.getSession(request, '/login');
+  const { publicId } = await authHelper.getSession(request, url, '/login');
   return settingsService.userSettings(publicId);
 }
 
 export async function action(
-  { request }: ActionFunctionArgs,
+  { request, url }: ActionFunctionArgs,
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
   settingsService: SettingsService = serverContainer[SettingsService.name],
 ) {
-  const [sessionData, newSettings] = await Promise.all([authHelper.getSession(request), request.json()]);
+  const [sessionData, newSettings] = await Promise.all([authHelper.getSession(request, url), request.json()]);
   if (sessionData) {
     await settingsService.saveUserSettings(sessionData.publicId, newSettings);
   }

--- a/app/routes/shlink-api-rpc-proxy.ts
+++ b/app/routes/shlink-api-rpc-proxy.ts
@@ -31,13 +31,13 @@ function resolveApiMethod(client: ShlinkApiClient, method?: string): Callback | 
 }
 
 export async function action(
-  { params, request }: ActionFunctionArgs,
+  { params, request, url }: ActionFunctionArgs,
   serversService: ServersService = serverContainer[ServersService.name],
   createApiClient: ApiClientBuilder = serverContainer.apiClientBuilder,
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
   console_ = console,
 ) {
-  const sessionData = await authHelper.getSession(request);
+  const sessionData = await authHelper.getSession(request, url);
   if (!sessionData) {
     return problemDetails({
       status: 403,

--- a/app/routes/shlink-component-wrapper.tsx
+++ b/app/routes/shlink-component-wrapper.tsx
@@ -14,13 +14,13 @@ import type { Route } from './+types/shlink-component-wrapper';
 import type { RouteComponentProps } from './types';
 
 export async function loader(
-  { request, params }: LoaderFunctionArgs,
+  { request, params, url }: LoaderFunctionArgs,
   tagsService: TagsService = serverContainer[TagsService.name],
   settingsService: SettingsService = serverContainer[SettingsService.name],
   authHelper: AuthHelper = serverContainer[AuthHelper.name],
 ): Promise<{ settings: Settings; tagColors: Record<string, string> }> {
   const { serverId: serverPublicId } = params;
-  const { publicId } = await authHelper.getSession(request, '/login');
+  const { publicId } = await authHelper.getSession(request, url, '/login');
   const [tagColors, settings] = await Promise.all([
     tagsService.tagColors({ userPublicId: publicId, serverPublicId }),
     settingsService.userSettings(publicId),

--- a/app/routes/users/list-users.tsx
+++ b/app/routes/users/list-users.tsx
@@ -32,17 +32,16 @@ import { useSession } from '../../auth/session-context';
 import { serverContainer } from '../../container/container.server';
 import type { ListUsersOptions, UserOrderableFields } from '../../users/UsersService.server';
 import { UsersService } from '../../users/UsersService.server';
-import { requestQueryParams } from '../../utils/request.server';
 import type { RouteComponentProps } from '../types';
 import type { Route } from './+types/list-users';
 import { DeleteUserModal } from './DeleteUserModal';
 import { RoleBadge } from './RoleBadge';
 
 export async function loader(
-  { request, params }: LoaderFunctionArgs,
+  { params, url }: LoaderFunctionArgs,
   usersService: UsersService = serverContainer[UsersService.name],
 ) {
-  const query = requestQueryParams(request);
+  const query = url.searchParams;
   const orderByParam = query.get('order-by');
   const orderBy = orderByParam ? stringToOrder<UserOrderableFields>(orderByParam) : {};
   const currentParams = {

--- a/app/utils/request.server.ts
+++ b/app/utils/request.server.ts
@@ -1,9 +1,0 @@
-/**
- * Returns a URLSearchParams object with the query parameters for provided request
- */
-export const requestQueryParams = (request: Request): URLSearchParams => new URL(request.url).searchParams;
-
-/**
- * Returns a specific query parameter for provided request
- */
-export const requestQueryParam = (request: Request, param: string) => requestQueryParams(request).get(param);

--- a/test/auth/auth-helper.server.test.ts
+++ b/test/auth/auth-helper.server.test.ts
@@ -30,7 +30,7 @@ describe('AuthHelper', () => {
       const authHelper = setUp();
       const request = buildRequest(url);
 
-      const response = await authHelper.login(request);
+      const response = await authHelper.login(request, new URL(url));
 
       expect(response.headers.get('Location')).toEqual(expectedRedirect);
       expect(authenticate).toHaveBeenCalled();
@@ -63,7 +63,7 @@ describe('AuthHelper', () => {
         const request = buildRequest();
 
         getSessionData.mockReturnValue(returnedSessionData);
-        const sessionData = await authHelper.getSession(request);
+        const sessionData = await authHelper.getSession(request, new URL('https://example.com'));
 
         expect(sessionData).toEqual(returnedSessionData);
       },
@@ -75,7 +75,9 @@ describe('AuthHelper', () => {
 
       getSessionData.mockReturnValue(undefined);
 
-      await expect(() => authHelper.getSession(request, '/redirect-here')).rejects.toThrow(
+      await expect(() =>
+        authHelper.getSession(request, new URL('https://example.com'), '/redirect-here'),
+      ).rejects.toThrow(
         expect.objectContaining({
           status: 302,
         }),
@@ -92,7 +94,7 @@ describe('AuthHelper', () => {
 
       getSessionData.mockReturnValue({ ...defaultSessionData, tempPassword: true });
 
-      await expect(() => authHelper.getSession(request)).rejects.toThrow(
+      await expect(() => authHelper.getSession(request, new URL('https://example.com'))).rejects.toThrow(
         expect.objectContaining({
           status: 302,
         }),
@@ -110,7 +112,7 @@ describe('AuthHelper', () => {
       const request = buildRequest();
 
       getSessionData.mockReturnValue(returnedSessionData);
-      const result = await authHelper.isAuthenticated(request);
+      const result = await authHelper.isAuthenticated(request, new URL('https://example.com'));
 
       expect(result).toEqual(!!returnedSessionData);
       expect(getSession).toHaveBeenCalled();

--- a/test/middleware/middleware.server.test.ts
+++ b/test/middleware/middleware.server.test.ts
@@ -24,12 +24,13 @@ describe('middleware', () => {
     const authHelper: AuthHelper = fromPartial({ getSession });
 
     it('sets session in context', async () => {
+      const url = new URL('https://example.com');
       const session = fromPartial<SessionData>({ role: 'admin', publicId: '123' });
       getSession.mockResolvedValue(session);
 
-      await authMiddleware(fromPartial({ request, context: createContext() }), next, authHelper);
+      await authMiddleware(fromPartial({ request, url, context: createContext() }), next, authHelper);
 
-      expect(getSession).toHaveBeenCalledWith(request, '/login');
+      expect(getSession).toHaveBeenCalledWith(request, url, '/login');
       expect(set).toHaveBeenCalledWith(expect.anything(), session);
     });
   });

--- a/test/routes/index/home.server.test.ts
+++ b/test/routes/index/home.server.test.ts
@@ -20,10 +20,11 @@ describe('home', () => {
       getUserServers.mockResolvedValue(servers);
 
       const request: Request = fromPartial({});
-      const data = await loader(fromPartial({ request }), serversService, authHelper);
+      const url = new URL('https://example.com');
+      const data = await loader(fromPartial({ request, url }), serversService, authHelper);
 
       expect(data.servers).toStrictEqual(servers);
-      expect(getSession).toHaveBeenCalledWith(request, '/login');
+      expect(getSession).toHaveBeenCalledWith(request, url, '/login');
       expect(getUserServers).toHaveBeenCalledWith(sessionData.publicId);
     });
 

--- a/test/routes/login.server.test.ts
+++ b/test/routes/login.server.test.ts
@@ -10,9 +10,11 @@ describe('login', () => {
   describe('action', () => {
     it('authenticates user', () => {
       const request = fromPartial<Request>({});
-      action(fromPartial({ request }), authHelper);
+      const url = new URL('https://example.com');
 
-      expect(login).toHaveBeenCalledWith(request);
+      action(fromPartial({ request, url }), authHelper);
+
+      expect(login).toHaveBeenCalledWith(request, url);
     });
 
     it.each([{ message: 'Incorrect password' }, { message: 'User not found' }])(
@@ -21,7 +23,8 @@ describe('login', () => {
         login.mockRejectedValue(new Error(message));
 
         const request = fromPartial<Request>({});
-        const response = await action(fromPartial({ request }), authHelper);
+        const url = new URL('https://example.com');
+        const response = await action(fromPartial({ request, url }), authHelper);
 
         expect(response).toEqual({ error: true });
       },

--- a/test/routes/profile/profile.server.test.ts
+++ b/test/routes/profile/profile.server.test.ts
@@ -19,10 +19,8 @@ describe('profile', () => {
       action(
         fromPartial({
           context: { get: () => ({}) },
-          request: {
-            url: `http://example.com?action=${profileAction}`,
-            formData: vi.fn().mockResolvedValue(new FormData()),
-          },
+          request: { formData: vi.fn().mockResolvedValue(new FormData()) },
+          url: new URL(`http://example.com?action=${profileAction}`),
         }),
         usersService,
         authHelper,

--- a/test/routes/save-tags-colors.server.test.ts
+++ b/test/routes/save-tags-colors.server.test.ts
@@ -11,14 +11,15 @@ describe('save-tags-colors', () => {
   const authHelper = fromPartial<AuthHelper>({ getSession });
 
   const callAction = (args: ActionFunctionArgs) => action(args, tagsService, authHelper);
+  const url = new URL('https://example.com');
 
   it('skips updates if there is no user authenticated', async () => {
     const request = fromPartial<ActionFunctionArgs['request']>({});
 
-    const resp = await callAction(fromPartial({ params: { serverId: '123' }, request }));
+    const resp = await callAction(fromPartial({ params: { serverId: '123' }, request, url }));
 
     expect(resp.status).toEqual(204);
-    expect(getSession).toHaveBeenCalledWith(request);
+    expect(getSession).toHaveBeenCalledWith(request, url);
     expect(updateTagColors).not.toHaveBeenCalled();
   });
 
@@ -28,10 +29,10 @@ describe('save-tags-colors', () => {
     const colors = { foo: 'red' };
     const request = fromPartial<ActionFunctionArgs['request']>({ json: vi.fn().mockResolvedValue(colors) });
 
-    const resp = await callAction(fromPartial({ params: { serverId: '123' }, request }));
+    const resp = await callAction(fromPartial({ params: { serverId: '123' }, request, url }));
 
     expect(resp.status).toEqual(204);
-    expect(getSession).toHaveBeenCalledWith(request);
+    expect(getSession).toHaveBeenCalledWith(request, url);
     expect(updateTagColors).toHaveBeenCalledWith(expect.objectContaining({ colors, userPublicId: '1' }));
   });
 });

--- a/test/routes/servers/list-servers.server.test.ts
+++ b/test/routes/servers/list-servers.server.test.ts
@@ -31,7 +31,7 @@ describe('list-servers', () => {
     const runLoader = ({ role, publicId, queryString, page }: RunLoader) =>
       loader(
         fromPartial({
-          request: fromPartial({ url: `https://example.com/?${queryString}` }),
+          url: new URL(`https://example.com/?${queryString}`),
           context: { get: vi.fn().mockReturnValue(fromPartial<SessionData>({ role, publicId })) },
           params: { page },
         }),

--- a/test/routes/settings.server.test.ts
+++ b/test/routes/settings.server.test.ts
@@ -31,15 +31,16 @@ describe('settings', () => {
   describe('action', () => {
     const setUp = () => (args: ActionFunctionArgs) => settingsAction(args, authHelper, settingsService);
     const request = fromPartial<Request>({ json: vi.fn().mockResolvedValue({}) });
+    const url = new URL('https://example.com');
 
     it('does not save settings when user is not logged in', async () => {
       const action = setUp();
 
       getSession.mockResolvedValue(undefined);
 
-      await action(fromPartial({ request }));
+      await action(fromPartial({ request, url }));
 
-      expect(getSession).toHaveBeenCalledWith(request);
+      expect(getSession).toHaveBeenCalledWith(request, url);
       expect(saveUserSettings).not.toHaveBeenCalled();
     });
 
@@ -48,9 +49,9 @@ describe('settings', () => {
 
       getSession.mockResolvedValue({ publicId: '1' });
 
-      await action(fromPartial({ request }));
+      await action(fromPartial({ request, url }));
 
-      expect(getSession).toHaveBeenCalledWith(request);
+      expect(getSession).toHaveBeenCalledWith(request, url);
       expect(saveUserSettings).toHaveBeenCalledWith('1', {});
     });
   });

--- a/test/routes/users/list-users.server.test.ts
+++ b/test/routes/users/list-users.server.test.ts
@@ -14,7 +14,7 @@ describe('list-users', () => {
       listUsers.mockResolvedValue(fromPartial({}));
 
       await runLoader({
-        request: fromPartial({ url: 'https://example.com' }),
+        url: new URL('https://example.com'),
         params: { page: '5' },
       });
 


### PR DESCRIPTION
One of the future flags that is now enabled in React Router 8 changes how the request URL is parsed, and that was missed when originally migrating to this version.

Changes applied here are as per the upgrade guide https://reactrouter.com/upgrading/v7#futurev8_passthroughrequests